### PR TITLE
Remove trailing slash

### DIFF
--- a/git.lua
+++ b/git.lua
@@ -13,7 +13,7 @@ local function pathname(path)
     local prefix = ""
     local i = path:find("[\\/:][^\\/:]*$")
     if i then
-        prefix = path:sub(1, i)
+        prefix = path:sub(1, i-1)
     end
     return prefix
 end


### PR DESCRIPTION
pathname wasn't traversing up directories because the prefix being returned contained the trailing slash, so the next time pathname was called the regex in path:find was matching on the trailing slash and returning the path unmodified.

P.S. This is way better than my original proposal with chdir.