### PR TITLE
[git] Add alias autocompletion

### DIFF
--- a/git.lua
+++ b/git.lua
@@ -112,6 +112,24 @@ local function branches(token)
     return res
 end
 
+local function alias(token)
+    local res = {}
+
+    f = assert (io.popen ("git config --get-regexp alias"))
+
+    for line in f:lines() do
+        local alias, command = line:match("alias%.(.-)%s(.+)$")
+        local start = alias:find(token, 1, true)
+        if start and start == 1 then
+            table.insert(res, alias)
+        end
+    end
+
+    f:close()
+
+    return res
+end
+
 local function remotes(token)
     local res = {}
 
@@ -230,6 +248,7 @@ local merge_strategies = parser({
 
 local git_parser = parser(
     {
+        {alias},
         "add" .. parser({files},
             "-n", "--dry-run",
             "-v", "--verbose",


### PR DESCRIPTION
This resolves #24 

One lack feature is that seems linux autocompletion understands main command behind alias, and offers its autocompletion too

~/.gitconfig

    [alias]
    ci = commit

So when issuing

    $ git ci <TAB>

it offers commit autocompletion. This implementation does not.