### PR TITLE
Fix for Nil needle value when calling clink.is_match()

### DIFF
--- a/vagrant.lua
+++ b/vagrant.lua
@@ -24,7 +24,7 @@ local vagrant_parser = parser({
     "connect",
     "destroy" .. parser("-f", "--force"),
     "halt" .. parser("-f", "--force"),
-    "init" .. parser(boxes(), {}, "--output"),
+    "init" .. parser({boxes}, {}, "--output"),
     "package" .. parser("--base", "--output", "--include", "--vagrantfile"),
     "plugin" .. parser({
         "install" .. parser(


### PR DESCRIPTION
Using latest master branch (`2491d21831`)

```
[path]/modules/funclib.lua:9: Nil needle value when calling clink.is_match()
```
I tracked error down to `vagrant.lua` file and probably wrong use of the boxes variable.

This is my first encounter with lua so I fixed the usage based on how the macher result is used in other extensions.