### PR TITLE
Remove outdated info about extended branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Completion files to [clink](https://github.com/mridgers/clink) util
 Notes
 =====
 
-Master branch of this repo contains only limited set of completions, including ones for git, npm and chocolatey. If you're want more, consider switching to `extended` branch. If you're still lack of functionality, post a feature request.
+Master branch of this repo contains all available completions. If you lack some functionality, post a feature request.
 
 Some of completion generators in this bundle uses features from latest clink distribuition. If you get an error messages in console while using these completions, consider upgrading clink to latest version.
 


### PR DESCRIPTION
This pull request removes some outdated info about the now-tombstoned extended branch from the README.md of the master branch. That readme is displayed by github, so it should contain up-to-date information.