### PR TITLE
[npm] Resolve lua error when package.json is empty

### DIFF
--- a/npm.lua
+++ b/npm.lua
@@ -206,6 +206,7 @@ function npm_prompt_filter()
     package_file:close()
 
     local package = JSON:decode(package_data)
+    if not package then return false end
     if not package.name and not package.version then return false end
 
     local package_name = package.name or "<no name>"


### PR DESCRIPTION
If you `touch package.json` you will get the following error:
`clink-completions/npm.lua:210: attempt to index local 'package' (a nil value)`
This commit adds a check to see if package is not nil before attempting to use it.