### PR TITLE
[chore] Remove trailing white space to pass CI

### DIFF
--- a/angular-cli.lua
+++ b/angular-cli.lua
@@ -15,8 +15,8 @@ local asset_sizes_parser = parser({
 })
 
 local build_parser = parser({
-    "--environment=", "-e", 
-    "--environment=dev", "-dev", 
+    "--environment=", "-e",
+    "--environment=dev", "-dev",
     "--environment=prod", "-prod",
     "--output-path", "-o",
     "--watch", "-w",
@@ -47,7 +47,7 @@ local generate_parser = parser({
     "pipe", "p",
     "route", "r",
     "service", "s"
-},{     
+},{
     "--dry-run", "-d",
     "--verbose", "-v",
     "--pod", "-p",
@@ -61,7 +61,7 @@ local help_parser = parser({
     "--json"
 })
 
-local init_parser = parser({ 
+local init_parser = parser({
     "--dry-run", "-d",
     "--verbose", "-v",
     "--blueprint", "-b",
@@ -78,7 +78,7 @@ local init_parser = parser({
     "--inline-template", "-it"
 })
 
-local new_parser = parser({ 
+local new_parser = parser({
     "--dry-run", "-d",
     "--verbose", "-v",
     "--blueprint", "-b",
@@ -107,7 +107,7 @@ local serve_parser = parser({
     "--live-reload-base-url", "-lrbu",
     "--live-reload-port", "-lrp",
     "--live-reload-live-css",
-    "--environment", "-e", 
+    "--environment", "-e",
     "--environment=development", "-dev",
     "--environment=production", "-prod",
     "--output-path", "-op", "-out",
@@ -149,7 +149,7 @@ local test_parser = parser({
     "--module", "-m",
     "--watch", "--watcher", "-w",
     "--launch",
-    "--reporter", "-r", 
+    "--reporter", "-r",
     "--silent",
     "--test-page",
     "--page",
@@ -182,7 +182,7 @@ local ng_parser = parser({
     "test"..test_parser, "t"..test_parser,
     "e2e",
     "lint",
-    "version"..version_parser, "v"..version_parser, "--version"..version_parser, "-v"..version_parser, 
+    "version"..version_parser, "v"..version_parser, "--version"..version_parser, "-v"..version_parser,
     "completion",
     "doc",
     "make-this-awesome",

--- a/modules/funclib.lua
+++ b/modules/funclib.lua
@@ -34,7 +34,7 @@ end
 exports.map = function (tbl, map_func)
     assert(tbl == nil or type(tbl) == "table",
         "First argument must be either table or nil")
-    
+
     assert(map_func == nil or type(map_func) == "function",
         "Second argument must be either function or nil")
 
@@ -75,7 +75,7 @@ end
  --    a table then its values is copied to the end of resultant table. If the
  --    parameter is single value, then it is appended to the resultant table. If
  --    the input value is 'nil', then it is omitted.
- -- 
+ --
  -- @return a result of concatenation. The result is always a table.
 exports.concat = function (...)
     local input = {...}


### PR DESCRIPTION
This removes the extra trailing white space that exists in a few files to get CI to pass.