### PR TITLE
Enhance regex for finding provision names

### DIFF
--- a/vagrant.lua
+++ b/vagrant.lua
@@ -50,7 +50,7 @@ local get_provisions = function ()
     for line in vagrant_file:lines() do
         line = delete_ruby_comment(line)
         if not is_empty(line) then
-            local provision_name = line:match('.vm.provision[ \r\t]+\"([A-z]+[A-z0-9]*)\"')
+            local provision_name = line:match('.vm.provision[ \r\t]+[\"|\']([A-z]+[A-z0-9|-]*)[\"|\']')
 
             if not is_empty(provision_name) then
                 table.insert(provisions, provision_name)


### PR DESCRIPTION
# Improvements
* name can be write down with apostrophe 
* name can include hyphen - or underscore _

# Tests:
* [x] .vm.provision 'CamelCase'
* [x] .vm.provision 'camel-case'
* [x] .vm.provision 'camel_case'
* [x] .vm.provision "Quote"