### PR TITLE
Close file after usage

### DIFF
--- a/vagrant.lua
+++ b/vagrant.lua
@@ -57,6 +57,7 @@ local get_provisions = function ()
             end
         end
     end
+    vagrant_file:close()
     return provisions
 end
 


### PR DESCRIPTION
# Reason
I noticed in my normal work that after a change of `Vagrantfile` I had problems with git. The cause was very simple I didn't close this file.

# Test
* [x] Invoke command and try to move `Vagrantfile` to different location