### PR TITLE
[git] Add support for detecting branch names in worktrees

### DIFF
--- a/git.lua
+++ b/git.lua
@@ -12,7 +12,7 @@ local parser = clink.arg.new_parser
  -- @return table  List of remote branches
 local function list_packed_refs(dir)
     local result = w()
-    local git_dir = dir or git.get_git_dir()
+    local git_dir = dir or git.get_git_common_dir()
     if not git_dir then return result end
 
     local packed_refs_file = io.open(git_dir..'/packed-refs')
@@ -31,7 +31,7 @@ local function list_packed_refs(dir)
 end
 
 local function list_remote_branches(dir)
-    local git_dir = dir or git.get_git_dir()
+    local git_dir = dir or git.get_git_common_dir()
     if not git_dir then return w() end
 
     return w(path.list_files(git_dir..'/refs/remotes', '/*',
@@ -46,7 +46,7 @@ end
  -- @param string [dir]  Git directory, where to search for remote branches
  -- @return table  List of branches.
 local function list_local_branches(dir)
-    local git_dir = dir or git.get_git_dir()
+    local git_dir = dir or git.get_git_common_dir()
     if not git_dir then return w() end
 
     local result = w(path.list_files(git_dir..'/refs/heads', '/*',
@@ -56,7 +56,7 @@ local function list_local_branches(dir)
 end
 
 local branches = function (token)
-    local git_dir = git.get_git_dir()
+    local git_dir = git.get_git_common_dir()
     if not git_dir then return w() end
 
     return list_local_branches(git_dir)
@@ -92,7 +92,7 @@ end
 
 local function remotes(token)  -- luacheck: no unused args
     local result = w()
-    local git_dir = git.get_git_dir()
+    local git_dir = git.get_git_common_dir()
     if not git_dir then return result end
 
     local git_config = io.open(git_dir..'/config')
@@ -112,7 +112,7 @@ end
 
 local function local_or_remote_branches(token)
     -- Try to resolve .git directory location
-    local git_dir = git.get_git_dir()
+    local git_dir = git.get_git_common_dir()
     if not git_dir then return w() end
 
     return list_local_branches(git_dir)
@@ -128,7 +128,7 @@ local function checkout_spec_generator(token)
             return path.is_real_dir(file)
         end)
 
-    local git_dir = git.get_git_dir()
+    local git_dir = git.get_git_common_dir()
 
     local local_branches = branches(token)
     local remote_branches = list_remote_branches(git_dir)
@@ -171,7 +171,7 @@ local function checkout_spec_generator(token)
 end
 
 local function push_branch_spec(token)
-    local git_dir = git.get_git_dir()
+    local git_dir = git.get_git_common_dir()
     if not git_dir then return w() end
 
     local plus_prefix = token:sub(0, 1) == '+'

--- a/modules/gitutil.lua
+++ b/modules/gitutil.lua
@@ -45,6 +45,20 @@ exports.get_git_dir = function (start_dir)
         or (parent_path ~= start_dir and exports.get_git_dir(parent_path) or nil)
 end
 
+exports.get_git_common_dir = function (start_dir)
+    local git_dir = exports.get_git_dir(start_dir)
+    if not git_dir then return git_dir end
+    local commondirfile = io.open(git_dir..'/commondir')
+    if commondirfile then
+        -- If there's a commondir file, we're in a git worktree
+        local commondir = commondirfile:read()
+        commondirfile.close()
+        return path.is_absolute(commondir) and commondir
+            or git_dir..'/'..commondir
+    end
+    return git_dir
+end
+
 ---
  -- Find out current branch
  -- @return {nil|git branch name}


### PR DESCRIPTION
With worktrees, there's the main `.git` dir (contains objects and refs) and the per-worktree directories (containing index etc.). Starting from the per-worktree directory, the main dir can be found by following the link in the `commondir` file (usually `../..`).