### PR TITLE
Fix stash completions (0 based).

### DIFF
--- a/git.lua
+++ b/git.lua
@@ -235,7 +235,7 @@ local stashes = function(token)  -- luacheck: no unused args
     -- make a dictionary of stash time and stash comment to
     -- be able to sort stashes by date/time created
     for stash in stash_file:lines() do
-        local stash_time, stash_name = stash:match('(%d%d%d%d%d%d%d%d%d%d) %+%d%d%d%d%s+(.*)')
+        local stash_time, stash_name = stash:match('(%d%d%d%d%d%d%d%d%d%d) [+-]%d%d%d%d%s+(.*)')
         if (stash_name and stash_name) then
             stashes[stash_time] = stash_name
         end

--- a/git.lua
+++ b/git.lua
@@ -259,7 +259,7 @@ local stashes = function(token)  -- luacheck: no unused args
     local ret = {}
     local ret_filter = {}
     for i,v in ipairs(stash_times) do
-        table.insert(ret, "stash@{"..i.."}")
+        table.insert(ret, "stash@{"..(i-1).."}")
         table.insert(ret_filter, "stash@{"..(i-1).."}    "..stashes[v])
     end
 


### PR DESCRIPTION
Fixes an off by one error.

Stash names are 0 based.  The stash name completions are _displayed_ as
being 0 based ("stash@{0}", "stash@{1}", etc), but the actual returned
completions are 1 based ("stash@{1}", "stash@{2}", etc) so using the
`menu-complete` family of commands skips stash 0, and can insert an
incorrect stash _N_ completion.