### PR TITLE
scoop.lua: improve profile path extraction

### DIFF
--- a/scoop.lua
+++ b/scoop.lua
@@ -9,12 +9,13 @@ local w = require("tables").wrap
 local concat = require("funclib").concat
 
 local parser = clink.arg.new_parser
+local profile = os.getenv("home") or os.getenv("USERPROFILE")
 
 local function scoop_folder()
     local folder = os.getenv("SCOOP")
 
     if not folder then
-        folder = os.getenv("home") .. "\\scoop"
+        folder = profile .. "\\scoop"
     end
 
     return folder
@@ -31,7 +32,7 @@ local function scoop_global_folder()
 end
 
 local function scoop_load_config() -- luacheck: no unused args
-    local file = io.open(os.getenv("home") .. "\\.config\\scoop\\config.json")
+    local file = io.open(profile .. "\\.config\\scoop\\config.json")
     -- If there is no such file, then close handle and return
     if file == nil then
         return w()


### PR DESCRIPTION
I discovered that os.getenv("home") returned nil on my win7 machine because with the new version of clink https://github.com/chrisant996/clink/issues/32 it gave me the error that it was not able to concatenate a nil value (in the provious clink version 0.4.9 it did't gave me the error but the value is nil as well)

os.getenv("USERPROFILE") should be used instead of os.getenv("home") because it returns the value the functions expect.

BUT I don't know much about lua programming so I made this change to keep it compatible but add the option to get the value in the second method as well.