### PR TITLE
Fix scoop.lua to work on Windows

### DIFF
--- a/scoop.lua
+++ b/scoop.lua
@@ -14,7 +14,7 @@ local function scoop_folder()
     local folder = os.getenv("SCOOP")
 
     if not folder then
-        folder = os.getenv("home") .. "\\scoop"
+        folder = os.getenv("USERPROFILE") .. "\\scoop"
     end
 
     return folder
@@ -31,7 +31,7 @@ local function scoop_global_folder()
 end
 
 local function scoop_load_config() -- luacheck: no unused args
-    local file = io.open(os.getenv("home") .. "\\.config\\scoop\\config.json")
+    local file = io.open(os.getenv("USERPROFILE") .. "\\.config\\scoop\\config.json")
     -- If there is no such file, then close handle and return
     if file == nil then
         return w()


### PR DESCRIPTION
The *scoop.lua* throws following error on Windows 10:
![image](https://user-images.githubusercontent.com/16168755/103111489-f1e9f580-464d-11eb-94f8-2d5b180be8ee.png)

This is caused by reading non-existing *%HOME%* environment variable in line **17**:
![image](https://user-images.githubusercontent.com/16168755/103111521-44c3ad00-464e-11eb-9d36-8a8ba32c9716.png)
and in line **34**:
![image](https://user-images.githubusercontent.com/16168755/103111545-7d638680-464e-11eb-9fa7-3fe73f41ed17.png)

On Windows *%USERPROFILE%* variable should be used.

**EDIT:**
@vladimir-kotikov: PR #134 also fixes the issue (I've missed it, sorry @nixxo ), so either merge PR #134 or this.