### PR TITLE
allow - in known hosts

### DIFF
--- a/ssh.lua
+++ b/ssh.lua
@@ -24,7 +24,7 @@ end
 local function list_known_hosts()
     return read_lines(clink.get_env("userprofile") .. "/.ssh/known_hosts")
         :map(function (line)
-            return line:match('^([%w.]*).*')
+            return line:match('^([%w-.]*).*')
         end)
         :filter()
 end


### PR DESCRIPTION
In regex filtering the list of known hosts, a minus char, i.e., `-` is needed to correctly work with hostnames like `host-name.com`