### PR TITLE
Fast git_prompt_filter

### DIFF
--- a/git_prompt.lua
+++ b/git_prompt.lua
@@ -3,39 +3,26 @@ local gitutil = require('gitutil')
 
 -- TODO: cache config based on some modification indicator (system mtime, hash)
 
--- this code is stolen from https://github.com/Dynodzzo/Lua_INI_Parser/blob/master/LIP.lua
--- Resolve licensing issues before exposing
-local function load_ini(fileName)
-    assert(type(fileName) == 'string', 'Parameter "fileName" must be a string.')
-    local file = io.open(fileName, 'r')
+local function load_git_config(git_dir)
+    if not git_dir then return nil end
+    local file = io.open(git_dir.."/config", 'r')
     if not file then return nil end
 
-    local data = {};
+    local config = {};
     local section;
     for line in file:lines() do
-        local tempSection = line:match('^%[([^%[%]]+)%]$');
-        if tempSection then
-            section = tonumber(tempSection) and tonumber(tempSection) or tempSection;
-            data[section] = data[section] or {}
-        end
-
-        local param, value = line:match('^%s-([%w|_]+)%s-=%s+(.+)$')
-        if(param and value ~= nil)then
-            if(tonumber(value))then
-                value = tonumber(value);
-            elseif(value == 'true')then
-                value = true;
-            elseif(value == 'false')then
-                value = false;
+        if (line:sub(1,1) == "[" and line:sub(-1) == "]") then
+            section = line:sub(2,-2)
+            config[section] = config[section] or {}
+        else
+            local param, value = line:match('^%s-([%w|_]+)%s-=%s+(.+)$')
+            if (param and value ~= nil) then
+                config[section][param] = value
             end
-            if(tonumber(param))then
-                param = tonumber(param);
-            end
-            data[section][param] = value
         end
     end
     file:close();
-    return data;
+    return config;
 end
 
 ---
@@ -49,12 +36,8 @@ local function escape(text)
     return text and text:gsub("([^%w])", "%%%1") or ""
 end
 
-local git = {}
-git.get_config = function (git_dir, section, param)
-    if not git_dir then return nil end
+local function get_git_config_value(git_config, section, param)
     if (not param) or (not section) then return nil end
-
-    local git_config = load_ini(git_dir..'/config')
     if not git_config then return nil end
 
     return git_config[section] and git_config[section][param] or nil
@@ -72,9 +55,10 @@ local function git_prompt_filter()
     if not branch then return false end
 
     -- for remote and ref resolution algorithm see https://git-scm.com/docs/git-push
-    local remote_to_push = git.get_config(git_dir, 'branch "'..branch..'"', 'remote') or ''
-    local remote_ref = git.get_config(git_dir, 'remote "'..remote_to_push..'"', 'push') or
-        git.get_config(git_dir, 'push', 'default')
+    local git_config = load_git_config(git_dir)
+    local remote_to_push = get_git_config_value(git_config, 'branch "'..branch..'"', 'remote') or ''
+    local remote_ref = get_git_config_value(git_config, 'remote "'..remote_to_push..'"', 'push') or
+        get_git_config_value(git_config, 'push', 'default')
 
     local text = remote_to_push
     if (remote_ref) then text = text..'/'..remote_ref end

--- a/git_prompt.lua
+++ b/git_prompt.lua
@@ -12,9 +12,13 @@ local function load_git_config(git_dir)
     local section;
     for line in file:lines() do
         if (line:sub(1,1) == "[" and line:sub(-1) == "]") then
-            section = line:sub(2,-2)
-            config[section] = config[section] or {}
-        else
+            if (line:sub(2,5) == "lfs ") then
+                section = nil -- skip LFS entries as there can be many and we never use them
+            else
+                section = line:sub(2,-2)
+                config[section] = config[section] or {}
+            end
+        elseif section then
             local param, value = line:match('^%s-([%w|_]+)%s-=%s+(.+)$')
             if (param and value ~= nil) then
                 config[section][param] = value


### PR DESCRIPTION
The current git_prompt_filter does a lot of unnecessary work, and as a result can cause the prompt to be very slow. This is particularly an issue when the `.git/config` file is large, which is often the case with LFS repos. See cmderdev/cmder#2484 for a detailed example.

This PR improves the performance of the git_prompt_filter ~17x by:
1. Avoiding parsing the config file multiple times
2. Avoiding using regexes to parse simple lines
3. Not attempting to convert values to number/boolean as we only ever need string
4. Skipping LFS entries

To compare I took the config file from the issue described in cmderdev/cmder#2484, and added in some perf measurements around key functions.

Before:
![image](https://user-images.githubusercontent.com/2031632/120908755-8ce5f300-c622-11eb-88a2-47ec612a7e24.png)

After:
![image](https://user-images.githubusercontent.com/2031632/120908882-df73df00-c623-11eb-81eb-b84f8fc8bb85.png)