### PR TITLE
Completions for yarn scripts/bins when used without 'run'

### DIFF
--- a/yarn.lua
+++ b/yarn.lua
@@ -138,7 +138,9 @@ local yarn_parser = parser({
         "--no-git-tag-version"
     ),
     "versions",
-    "why"..parser({modules})
+    "why"..parser({modules}),
+    bins,
+    scripts
     },
     "-h",
     "-v",


### PR DESCRIPTION
In the yarn CLI, `yarn run myscript` is equivalent to `yarn myscript`. 
> It’s also possible to leave out the `run` in this command, each script can be executed with its name
https://classic.yarnpkg.com/en/docs/cli/run

This is a frequently used shortcut. We already have completions for `yarn run`, but these don't show when you just do `yarn`. This PR just adds those same completions onto the root `yarn` parser.

e.g. With the following in package.json
```json
"scripts": {
  "myscript": "echo myscript",
  "add": "echo add"
},
"devDependencies": {
  "rimraf": "^3.0.2"
}
```
I now get
![image](https://user-images.githubusercontent.com/2031632/120942446-db0bfc80-c6dd-11eb-8df3-e3c7734cea53.png)

And I confirmed that when the script/bin conflicts with a built-in command (in which case the built-in command has preference), the completions for the command still show.
![image](https://user-images.githubusercontent.com/2031632/120942486-22928880-c6de-11eb-9a48-a1fb860753d6.png)
