### PR TITLE
Clink improvements

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,17 +1,25 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "cmd",
-    "args": ["/c"],
-    "isShellCommand": true,
-    "showOutput": "silent",
+    "args": [
+        "/c"
+    ],
     "tasks": [
         {
-            "taskName": "test",
-            "isTestCommand": true,
-            "showOutput": "always",
-            "suppressTaskName": false
+            "label": "test",
+            "type": "shell",
+            "command": "cmd",
+            "args": [
+                "/c",
+                "test"
+            ],
+            "problemMatcher": [],
+            "group": {
+                "_id": "test",
+                "isDefault": false
+            }
         }
     ]
 }

--- a/git.lua
+++ b/git.lua
@@ -235,7 +235,7 @@ local stashes = function(token)  -- luacheck: no unused args
     -- make a dictionary of stash time and stash comment to
     -- be able to sort stashes by date/time created
     for stash in stash_file:lines() do
-        local stash_time, stash_name = stash:match('(%d%d%d%d%d%d%d%d%d%d) %+%d%d%d%d%s+(.*)')
+        local stash_time, stash_name = stash:match('(%d%d%d%d%d%d%d%d%d%d) [+-]%d%d%d%d%s+(.*)')
         if (stash_name and stash_name) then
             stashes[stash_time] = stash_name
         end

--- a/git.lua
+++ b/git.lua
@@ -268,13 +268,27 @@ local stashes = function(token)  -- luacheck: no unused args
     -- generate matches and match filter table
     local ret = {}
     local ret_filter = {}
+    local clink_version_encoded = clink.version_encoded or 0
     for i,v in ipairs(stash_times) do
-        table.insert(ret, "stash@{"..(i-1).."}")
-        table.insert(ret_filter, "stash@{"..(i-1).."}    "..stashes[v])
+        local match = "stash@{"..(i-1).."}"
+        table.insert(ret, match)
+        if clink_version_encoded >= 10010012 then
+            table.insert(ret_filter, { match=match, type="word", description=stashes[v] })
+        elseif clink_version_encoded >= 10010009 then
+            table.insert(ret_filter, "stash@{"..(i-1).."}\x1b[m    "..stashes[v])
+        else
+            table.insert(ret_filter, "stash@{"..(i-1).."}    "..stashes[v])
+        end
     end
 
-    clink.match_display_filter = function ()
+    local function filter()
         return ret_filter
+    end
+
+    if clink_version_encoded >= 10010012 then
+        clink.ondisplaymatches(filter)
+    else
+        clink.match_display_filter = filter
     end
 
     return ret

--- a/git.lua
+++ b/git.lua
@@ -259,7 +259,7 @@ local stashes = function(token)  -- luacheck: no unused args
     local ret = {}
     local ret_filter = {}
     for i,v in ipairs(stash_times) do
-        table.insert(ret, "stash@{"..i.."}")
+        table.insert(ret, "stash@{"..(i-1).."}")
         table.insert(ret_filter, "stash@{"..(i-1).."}    "..stashes[v])
     end
 

--- a/git.lua
+++ b/git.lua
@@ -277,7 +277,6 @@ local stashes = function(token)  -- luacheck: no unused args
     -- generate matches and match filter table
     local ret = {}
     local ret_filter = {}
-    local clink_version_encoded = clink.version_encoded or 0
     for i,v in ipairs(stash_times) do
         local match = "stash@{"..(i-1).."}"
         table.insert(ret, match)
@@ -287,7 +286,7 @@ local stashes = function(token)  -- luacheck: no unused args
             -- description.  If the script does so, then the popup completion
             -- window is able to show the stash name plus a dimmed description,
             -- but only insert the stash name.
-            table.insert(ret_filter, { match=match, type="word", description=stashes[v] })
+            table.insert(ret_filter, { match=match, type="none", description=stashes[v] })
         else
             table.insert(ret_filter, match.."    "..stashes[v])
         end

--- a/git.lua
+++ b/git.lua
@@ -6,11 +6,21 @@ local matchers = require('matchers')
 local w = require('tables').wrap
 local clink_version = require('clink_version')
 local color = require('color')
-local parser = clink.arg.new_parser
+require('arghelper')
+local parser = function (...)
+    local p = clink.arg.new_parser(...):setendofflags()
+    p._deprecated = nil
+    return p
+end
 
 if clink_version.supports_color_settings then
     settings.add('color.git.star', 'bright green', 'Color for preferred branch completions')
 end
+
+local file_matches = clink.filematches or matchers.files
+local dir_matches = clink.dirmatches or matchers.dirs
+local files_parser = parser({file_matches})
+local dirs_parser = parser({dir_matches})
 
 ---
  -- Lists remote branches based on packed-refs file from git directory
@@ -370,7 +380,112 @@ local stashes = function(token)  -- luacheck: no unused args
     return ret
 end
 
+local function concept_guides()
+    if clink_version.supports_display_filter_description then
+        local r = io.popen("git help -g 2>nul")
+        if r then
+            local matches = {}
+            local color = "\x1b[1m"
+            local mark = " \x1b[22;32m*"
+            for line in r:lines() do
+                local guide, desc = line:match("^   ([^ ]+) +(.+)$")
+                if guide then
+                    table.insert(matches, { match=guide, display=color..guide..mark, description="Guide: "..desc } )
+                end
+            end
+            r:close()
+            return matches
+        end
+    end
+    return {}
+end
+
+local function all_commands()
+    if clink_version.supports_display_filter_description then
+        local r = io.popen("git help -a 2>nul")
+        if r then
+            local matches = {}
+            local prefix = "Command: "
+            local color = ""
+            for line in r:lines() do
+                local command, desc = line:match("^   ([^ ]+) +(.+)$")
+                if command then
+                    table.insert(matches, { match=command, display=color..command, description=prefix..desc } )
+                elseif line == "Command aliases" then
+                    prefix = "Alias: "
+                    color = "\x1b["..settings.get("color.doskey").."m"
+                end
+            end
+            r:close()
+            return matches
+        end
+    end
+    return {}
+end
+
+local mergesubtree_arg = parser({dir_matches})
+local placeholder_required_arg = parser({})
+-- Note: All these separate fromhistory parsers are necessary in order to
+-- collect from history separately.
+local batch_format_arg = parser({fromhistory=true, "%(objectname)", "%(objecttype)", "%(objectsize)", "%(objectsize:disk)", "%(deltabase)", "%(rest)"})
+local clone_filter_arg = parser({fromhistory=true})
 local color_opts = parser({"true", "false", "always"})
+local commit_trailer_arg = parser({fromhistory=true})
+local config_arg = parser({fromhistory=true})
+local contextlines_arg = parser({fromhistory=true})
+local depth_arg = parser({fromhistory=true})
+local diff_filter_arg = parser({fromhistory=true})
+local difftool_extcmd_arg = parser({fromhistory=true})
+local gpg_keyid_arg = parser({fromhistory=true})
+local merge_recursive_options = parser():_addexarg({
+    --ort and recursive
+    "ours", "theirs",
+    "ignore-space-change", "ignore-all-space", "ignore-space-at-eol", "ignore-cr-at-eol",
+    "renormalize", "no-renormalize",
+    "find-renames",
+    { "find-renames="..placeholder_required_arg, "n", "" },
+    { "rename-threshold="..placeholder_required_arg, "n", "" },
+    "subtree",
+    { "subtree="..mergesubtree_arg, "path", "" },
+    --recursive
+    "patience",
+    { "diff-algorithm="..parser({"patience", "minimal", "histogram", "myers"}), "algorithm", "" },
+    "no-renames",
+})
+local merge_strategies = parser({"resolve", "recursive", "ours", "octopus", "subtree"})
+local origin_arg = parser({fromhistory=true})
+local person_arg = parser({fromhistory=true})
+local pretty_formats_parser = parser({"oneline", "short", "medium", "full", "fuller", "reference", "email", "mboxrd", "raw", "format:"})
+local receive_pack_arg = parser({fromhistory=true})
+local regex_ignorelines_arg = parser({fromhistory=true})
+local regex_refs_arg = parser({fromhistory=true})
+local regex_worddiff_arg = parser({fromhistory=true})
+local repo_arg = parser({fromhistory=true})
+local shallow_since_arg = parser({fromhistory=true})
+local summary_limit_arg = parser({fromhistory=true})
+local untracked_files_arg = parser({"no", "normal", "all"})
+local x_cmd_arg = parser({fromhistory=true})
+
+local flag__abbrevequals = "--abbrev="..parser({5, 6, 8, 10, 12, 16, 20, 24, 32, 40})
+local flag__colorequals = "--color="..parser({"always", "auto", "never"})
+local flag__columnequals = "--column="..parser({"always", "auto", "never", "column", "row", "plain", "dense", "nodense"})
+local flag__conflictequals = '--conflict='..parser({'merge', 'diff3', 'zdiff3'})
+local flag__dateequals = "--date="..parser({"relative", "local", "iso", "iso-strict", "rfc", "short", "raw", "human", "unix", "default", "format:", "format-local:"})
+local flag__encoding = "--encoding="..parser({fromhistory=true}) --parser("UTF-8", "none")
+local flag__ignore_submodules = "--ignore-submodules="..parser({"none", "untracked", "dirty", "all"})
+local flag__whitespaceequals = "--whitespace="..parser({"nowarn", "warn", "fix", "error", "error-all"})
+
+local flagex__cleanupequals = { opteq=true, "--cleanup="..parser({"strip", "whitespace", "verbatim", "scissors", "default"}), 'option', '' }
+local flagex_c_config = { '-c'..config_arg, ' key=value', '' }
+local flagex__config = { '--config'..config_arg, ' key=value', '' }
+local flagex__depthdepth = { opteq=true, '--depth'..depth_arg, ' depth', '' }
+local flagex__gpgsignequals = { '--gpg-sign='..gpg_keyid_arg, 'keyid', '' }
+local flagex_s_mergestrategy = { '-s' .. merge_strategies, ' strategy', '' }
+local flagex__strategy = { opteq=true, '--strategy' .. merge_strategies, ' strategy', '' }
+local flagex_u_uploadpack = { '-u'..placeholder_required_arg, ' upload-pack', '' }
+local flagex__uploadpack = { opteq=true, '--upload-pack'..placeholder_required_arg, ' upload-pack', '' }
+local flagex_X_strategyoption = { '-X'..merge_recursive_options, ' option', '' }
+local flagex__strategyoption = { opteq=true, '--strategy-option'..merge_recursive_options, ' option', '' }
 
 local git_options = {
     "core.editor",
@@ -396,671 +511,1266 @@ local git_options = {
     "user.name", "user.email", "user.signingkey",
 }
 
-local config_parser = parser(
-    "--system", "--global", "--local", "--file"..parser({matchers.files}),
-    "--int", "--bool", "--path",
-    "-z", "--null",
-    "--add",
-    "--replace-all",
-    "--get", "--get-all", "--get-regexp", "--get-urlmatch",
-    "--unset", "--unset-all",
-    "--rename-section", "--remove-section",
-    "-l", "--list",
-    "--get-color", "--get-colorbool",
+--------------------------------------------------------------------------------
+-- Reusable groups of flags.
+
+local log_flags = {
+    "--decorate", "--decorate="..parser({"short", "full", "auto", "no"}), "--no-decorate",
+    "--decorate-refs="..regex_refs_arg, "--decorate-refs-exclude="..regex_refs_arg,
+    "--source",
+    "--mailmap", "--no-mailmap",
+    "--full-diff",
+    "--log-size",
+    { "-n"..placeholder_required_arg, " number", "" },
+    { opteq=true, "--max-count="..placeholder_required_arg, "number", "" },
+    { opteq=true, "--skip="..placeholder_required_arg, "number", "" },
+    { opteq=true, "--since="..placeholder_required_arg, "date", "" },
+    { opteq=true, "--after="..placeholder_required_arg, "date", "" },
+    { opteq=true, "--until="..placeholder_required_arg, "date", "" },
+    { opteq=true, "--before="..placeholder_required_arg, "date", "" },
+    { opteq=true, "--author="..person_arg },
+    { opteq=true, "--committer="..person_arg },
+    { opteq=true, "--grep="..placeholder_required_arg },
+    "--all-match",
+    "--invert-grep",
+    "-i", "--regexp-ignore-case",
+    "--basic-regexp",
+    "-E", "--extended-regexp",
+    "-F", "--fixed-strings",
+    "-P", "--perl-regexp",
+    "--merges", "--no-merges",
+    { opteq=true, "--min-parents="..placeholder_required_arg, "number", "" }, "--no-min-parents",
+    { opteq=true, "--max-parents="..placeholder_required_arg, "number", "" }, "--no-max-parents",
+    "--first-parent",
+    "--not",
+    "--all",
+    "--branches", { "--branches="..placeholder_required_arg, "glob", "" },
+    "--tags", { "--tags="..placeholder_required_arg, "glob", "" },
+    "--remotes", { "--remotes="..placeholder_required_arg, "glob", "" },
+    { opteq=true, "--glob="..placeholder_required_arg, "glob", "" },
+    { opteq=true, "--exclude="..placeholder_required_arg, "glob", "" },
+    "--single-worktree",
+    "--ignore-missing",
+    "--merge",
+}
+
+local log_history_flags = {
+    "--follow",
+    { "-L"..parser({fromhistory=true}), ":funcname:file|start,end:file", "" },
+    { opteq=true, "--grep-reflog="..placeholder_required_arg, "pattern", "" },
+    "--remove-empty",
+    --"--reflog",
+    --"--alternate-refs",
+    "--bisect",
+    "--stdin",
+    "--cherry-mark",
+    "--cherry-pick",
+    "--left-only",
+    "--right-only",
+    "--cherry",
+    "-g", "--walk-reflogs",
+    "--boundary",
+    "--simplify-by-decoration",
+    "--show-pulls",
+    "--full-history",
+    "--dense",
+    "--sparse",
+    "--simplify-merges",
+    "--ancestry-path",
+    "--date-order",
+    "--author-date-order",
+    "--topo-order",
+    "--reverse",
+}
+
+local commit_formatting_flags = {
+    "--pretty",
+    "--pretty="..pretty_formats_parser,
+    "--format="..pretty_formats_parser,
+    "--oneline",
+    "--abbrev-commit",
+    "--no-abbrev-commit",
+    flag__encoding,
+    { "--expand-tabs="..placeholder_required_arg, "n", "" },
+    "--expand-tabs",
+    "--no-expand-tabs",
+    "--notes",
+    { "--notes="..placeholder_required_arg, "ref", "" },
+    "--no-notes",
+    "--first-parent",
+    flag__dateequals,
+    "--parents",
+    "--children",
+    "--left-right",
+    "--graph",
+    "--show-linear-break",
+    { "--show-linear-break="..placeholder_required_arg, "barrier", "" },
+}
+
+local diff_flags = {
+    "-p", "-u", "--patch",
+    "-s", "--no-patch",
+    "-U", "--unified",
+    { opteq=true, "--output="..files_parser },
+    { opteq=true, "--output-indicator-new="..placeholder_required_arg, "char", "" },
+    { opteq=true, "--output-indicator-old="..placeholder_required_arg, "char", "" },
+    { opteq=true, "--output-indicator-context="..placeholder_required_arg, "char", "" },
+    "--raw",
+    "--patch-with-raw",
+    "--indent-heuristic",
+    "--no-indent-heuristic",
+    "--minimal",
+    "--patience",
+    "--histogram",
+    { opteq=true, "--anchored="..placeholder_required_arg, "text", "" },
+    { opteq=true, "--diff-algorithm="..parser({"patience", "minimal", "histogram", "default", "myers"}) },
+    "--stat",
+    { "--stat="..placeholder_required_arg, "width[,name-width[,count]]", "" },
+    "--compact-summary",
+    "--numstat",
+    "--shortstat",
+    "-X", "--dirstat",
+    "--dirstat="..parser({"changes", "lines", "files", "cumulative", "noncumulative", "{LIMIT_PERCENT}"}),
+    "--cumulative",
+    "--dirstat-by-file",
+    "--dirstat-by-file="..parser({"cumulative", "noncumulative", "{LIMIT_PERCENT}"}),
+    "--summary",
+    "--patch-with-stat",
+    "-z",
+    "--name-only",
+    "--name-status",
+    "--color",
+    flag__colorequals,
+    "--no-color",
+    "--color-moved",
+    "--color-moved="..parser({"no", "default", "plain", "blocks", "zebra", "dimmed-zebra"}),
+    "--no-color-moved",
+    "--color-moved-ws="..parser({"no", "ignore-space-at-eol", "ignore-space-change", "ignore-all-space", "allow-indentation-change"}),
+    "--no-color-moved-ws",
+    "--word-diff",
+    "--word-diff="..parser({"color", "plain", "porcelain", "none"}),
+    { opteq=true, "--word-diff-regex="..regex_worddiff_arg },
+    "--color-words", --"--color-words="..regex_worddiff_arg,
+    "--no-renames",
+    "--rename-empty",
+    "--no-rename-empty",
+    "--check",
+    "--ws-error-highlight="..parser({"context", "old", "new", "all", "default"}),
+    "--full-index",
+    "--binary",
+    "--abbrev",
+    flag__abbrevequals,
+    { "-B", "[n][/m]", "" },
+    "--break-rewrites",
+    { "--break-rewrites="..placeholder_required_arg, "[n]/[/m]", "" },
+    { "-M", "n", "" },
+    "--find-renames",
+    { "--find-renames="..placeholder_required_arg, "n", "" },
+    { "-C", "n", "" },
+    "--find-copies",
+    { "--find-copies="..placeholder_required_arg, "n", "" },
+    "--find-copies-harder",
+    "-D", "--irreversible-delete",
+    { "-l", "n", "" },
+    { opteq=true, "--diff-filter="..diff_filter_arg, "[ACDMRTUXB...*]", "" },
+    --{ "-S", "string", "" },
+    --{ "-G", "regex", "" },
+    { opteq=true, "--find-object="..placeholder_required_arg, "objid", "" },
+    "--pickaxe-all", "--pickaxe-regex",
+    "-O",
+    { opteq=true, "--skip-to="..files_parser },
+    { opteq=true, "--rotate-to="..files_parser },
+    "-R",
+    "--relative",
+    "--relative="..dirs_parser,
+    "--no-relative",
+    "-a", "--text",
+    "--ignore-cr-at-eol",
+    "--ignore-space-at-eol",
+    "-b", "--ignore-space-change",
+    "-w", "--ignore-all-space",
+    "--ignore-blank-lines",
+    "-I", { "--ignore-matching-lines="..regex_ignorelines_arg, "regex", "" },
+    { "--inter-hunk-context="..contextlines_arg, "numlines", "" },
+    "-W", "--function-context",
+    "--exit-code",
+    "--quiet",
+    "--ext-diff", "--no-ext-diff",
+    "--text-conv", "--no-text-conv",
+    "--ignore-submodules",
+    flag__ignore_submodules,
+    "--submodule", "--submodule="..parser({"short", "log", "diff"}),
+    { opteq=true, "--src-prefix="..parser({fromhistory=true}), "prefix", "" },
+    { opteq=true, "--dst-prefix="..parser({fromhistory=true}), "prefix", "" },
+    "--no-prefix",
+    { opteq=true, "--line-prefix="..parser({fromhistory=true}), "prefix", "" },
+    "--ita-invisible-in-index",
+    "-1", "--base",
+    "-2", "--ours",
+    "-3", "--theirs",
+    "-0",
+    { opteq=true, "--diff-merges="..parser({"off", "none", "on", "first-parent", "1", "separate", "m", "combined", "c", "dense-combined", "cc"}) },
+    "--no-diff-merges",
+    "-c", "--cc",
+    "-m",
+    "-t",
+    "--combined-all-paths",
+}
+
+local fetch_flags = {
+    '--all',
+    '-a', '--append',
+    '--atomic',
+    { opteq=true, '--depth='..placeholder_required_arg, 'depth', '' },
+    { opteq=true, '--deepen='..placeholder_required_arg, 'depth', '' },
+    { opteq=true, '--shallow-since='..shallow_since_arg, 'date', '' },
+    { opteq=true, '--shallow-exclude='..placeholder_required_arg, 'rev', '' },
+    '--unshallow',
+    '--update-shallow',
+    { opteq=true, '--negotiation-tip='..placeholder_required_arg, 'commit|glob', '' },
+    '--negotiate-only',
+    '--dry-run',
+    '-f', '--force',
+    '-k', '--keep',
+    '--prefetch',
+    '-p', '--prune',
+    '--no-tags',
+    { opteq=true, '--refmap='..placeholder_required_arg, 'refspec', '' },
+    '-t', '--tags',
+    '-j', { opteq=true, '--jobs='..placeholder_required_arg, 'n', '' },
+    '--set-upstream',
+    flagex__uploadpack,
+    --'--progress',
+    '--no-progress',
+    --'-o'..placeholder_required_arg, '--server-option='..placeholder_required_arg,
+    '--show-forced-updates',
+    '--no-show-forced-updates',
+    '-4', '--ipv4',
+    '-6', '--ipv6',
+}
+
+local merge_flags_common = {
+    flagex_s_mergestrategy,
+    flagex__strategy,
+    flagex_X_strategyoption,
+    flagex__strategyoption,
+    "-S", "--gpg-sign", "--no-gpg-sign",
+    flagex__gpgsignequals,
+    --"--verify",
+    "--no-verify",
+    "--verify-signatures", "--no-verify-signatures",
+    --"--progress",
+    "--no-progress",
+    "--autostash", "--no-autostash",
+    "-n", "--stat", "--no-stat",
+}
+
+local merge_flags = {
+    "--continue",
+    "--abort",
+    "--quit",
+    '-i', '--interactive',
+    "-q", "--quiet",
+    "-v", "--verbose",
+    "--rerere-autoupdate", "--no-rerere-autoupdate",
+}
+
+--------------------------------------------------------------------------------
+-- Command parsers.
+
+local add_parser = parser()
+:addarg(file_matches)
+:_addexflags({
+    "-n", "--dry-run",
+    "-v", "--verbose",
+    "-i", "--interactive",
+    "-p", "--patch",
     "-e", "--edit",
-    {git_options}
+    "-f", "--force",
+    "-u", "--update",
+    "--renormalize",
+    "-N", "--intent-to-add",
+    "-A", "--all",
+    "--no-all",
+    "--ignore-removal",
+    "--no-ignore-removal",
+    "--refresh",
+    "--ignore-errors",
+    "--ignore-missing",
+    "--sparse",
+    { opteq=true, "--chmod="..parser({"+x", "-x"}) },
+    { opteq=true, "--pathspec-from-file="..files_parser },
+    "--pathspec-file-nul",
+})
+
+local apply_parser = parser()
+:_addexflags({
+    "--stat",
+    "--numstat",
+    "--summary",
+    "--check",
+    "--index",
+    "--cached",
+    "--intent-to-add",
+    "-3", "--3way",
+    { opteq=true, "--build-fake-ancestor="..files_parser, "tmpfile", "" },
+    "-R", "--reverse",
+    "--reject",
+    "-z",
+    { "-p", "n", "" },
+    { "-C", "n", "" },
+    "--unidiff-zero",
+    "--apply",
+    "--no-add",
+    "--allow-binary-replacement", "--binary",
+    { opteq=true, "--exclude="..files_parser, "glob", "" },
+    { opteq=true, "--include="..files_parser, "glob", "" },
+    "--ignore-space-change", "--ignore-whitespace",
+    flag__whitespaceequals,
+    "--inaccurate-eof",
+    "-v", "--verbose",
+    "--recount",
+    { opteq=true, "--directory="..dirs_parser },
+    "--unsafe-paths",
+    "--allow-empty",
+})
+
+local blame_parser = parser()
+:addarg(file_matches)
+:_addexflags({
+    "--incremental",
+    "-b",
+    "--root",
+    "--show-stats",
+    --"--progress",
+    "--no-progress",
+    "--score-debug",
+    "-f", "--show-name",
+    "-n", "--show-number",
+    "-p", "--porcelain",
+    "--line-porcelain",
+    "-c", "-t", "-l", "-s",
+    "-e", "--show-email",
+    "-w",
+    "--ignore-rev",
+    { opteq=true, "--ignore-revs-file="..files_parser, "file", "" },
+    "--color-lines",
+    "--color-by-age",
+    "--minimal",
+    { "-S"..files_parser, " revs-file", "" },
+    { opteq=true, "--contents="..files_parser, "file", "" },
+    { "-C", "n", "" },
+    { "-M", "n", "" },
+    { "-L"..placeholder_required_arg, " :funcname|start,end", "" },
+    "--abbrev",
+    flag__abbrevequals,
+    "-l",
+    "-t",
+    { opteq=true, "--reverse="..placeholder_required_arg, "rev..rev", "" },
+})
+:_addexflags(commit_formatting_flags)
+
+local branch_parser = parser()
+:_addexflags({
+    "-v", "--verbose", --"--vv",
+    "-q", "--quiet",
+    "-t", "--track", "--track="..parser({"direct", "inherit"}), "--no-track",
+    "--set-upstream",
+    "-u", "--set-upstream-to", "--set-upstream-to="..placeholder_required_arg,
+    "--unset-upstream",
+    "--color", flag__colorequals, "--no-color",
+    "-r", "--remotes",
+    { opteq=true, "--contains"..placeholder_required_arg, " commit", "" },
+    { opteq=true, "--no-contains"..placeholder_required_arg, " commit", "" },
+    "--abbrev", flag__abbrevequals, "--no-abbrev",
+    "-a", "--all",
+    { "-d" .. parser({branches}):loop(1), " branch", "" },
+    { opteq=true, "--delete" .. parser({branches}):loop(1), " branch", "" },
+    { "-D" .. parser({branches}):loop(1), " branch", "" },
+    "-m", "--move", "-M",
+    "-c", "--copy", "-C",
+    "-i", "--ignore-case",
+    "-l", "--list",
+    "--show-current",
+    "--create-reflog",
+    "--edit-description",
+    "-f", "--force",
+    { opteq=true, "--merged"..placeholder_required_arg, " commit", "" },
+    { opteq=true, "--no-merged"..placeholder_required_arg, " commit", "" },
+    "--column",
+    flag__columnequals,
+    "--no-column",
+    { "--sort="..placeholder_required_arg, "key", "" },
+    { opteq=true, "--points-at", " object", "" },
+    { opteq=true, "--format"..placeholder_required_arg, " format", "" },
+})
+
+local catfile_parser = parser()
+:_addexflags({
+    '-t',
+    '-s',
+    '-e',
+    '-p',
+    '--textconv',
+    '--filters',
+    { opteq=true, '--path='..files_parser, 'path', '' },
+    '--batch',
+    { '--batch='..batch_format_arg, 'format', '' },
+    '--batch-check',
+    { '--batch-check='..batch_format_arg, 'format', '' },
+    '--batch-all-objects',
+    '--buffer',
+    '--unordered',
+    '--allow-unknown-type',
+    '--follow-symlinks',
+})
+
+local checkout_parser = parser()
+:addarg(checkout_spec_generator)
+:_addexflags({
+    '-q', '--quiet',
+    --'--progress',
+    '--no-progress',
+    { '-b'..placeholder_required_arg, ' new-branch', '' },
+    { '-B'..placeholder_required_arg, ' new-branch', '' },
+    '-l',
+    '-d', '--detach',
+    '-t', '--track', '--track='..parser({'direct', 'inherit'}), '--no-track',
+    '--guess', '--no-guess',
+    { opteq=true, '--orphan'..placeholder_required_arg, ' new-branch', '' },
+    '-2', '--ours',
+    '-3', '--theirs',
+    '-f', '--force',
+    '-m', '--merge',
+    --'--overwrite-ignore',
+    '--no-overwrite-ignore',
+    '--recurse-submodules', '--no-recurse-submodules',
+    --'--overlay',
+    '--no-overlay',
+    flag__conflictequals,
+    '-p', '--patch',
+    '--ignore-skip-worktree-bits',
+    '--ignore-other-worktrees',
+    '--pathspec-from-file='..files_parser,
+    '--pathspec-file-nul',
+})
+
+local cherrypick_parser = parser()
+:_addexflags({
+    "-e", "--edit",
+    flagex__cleanupequals,
+    "-x",
+    "-r",
+    { "-m"..placeholder_required_arg, " parent-number", "" },
+    { opteq=true, "--mainline"..placeholder_required_arg, " parent-number", "" },
+    "-n", "--no-commit",
+    "-s", "--signoff",
+    "-S", "--gpg-sign", "--no-gpg-sign",
+    flagex__gpgsignequals,
+    "--ff",
+    "--allow-empty",
+    "--allow-empty-message",
+    "--keep-redundant-commits",
+    flagex_s_mergestrategy,
+    flagex__strategy,
+    flagex_X_strategyoption,
+    flagex__strategyoption,
+    "--rerere-autoupdate", "--no-rerere-autoupdate",
+    "--continue",
+    "--skip",
+    "--quit",
+    "--abort",
+})
+
+local clone_parser = parser()
+:_addexflags({
+    { opteq=true, '--template'..dirs_parser, ' dir', '' },
+    '-l', '--local',
+    '-s', '--shared',
+    '--no-hardlinks',
+    '-q', '--quiet',
+    '-v', '--verbose',
+    '-n', '--no-checkout',
+    --'--progress',
+    --'--server-option='..placeholder_required_arg,
+    '--reject-shallow', '--no-reject-shallow',
+    '--bare',
+    '--sparse',
+    { opteq=true, '--filter='..clone_filter_arg, 'filter-spec', '' },
+    '--mirror',
+    '-o'..origin_arg, { opteq=true, '--origin='..origin_arg },
+    { '-b'..placeholder_required_arg, ' name', '' },
+    { opteq=true, '--branch'..placeholder_required_arg, ' name', '' },
+    flagex_u_uploadpack,
+    flagex__uploadpack,
+    { opteq=true, '--reference'..files_parser, ' repo', '' },
+    { opteq=true, '--reference-if-able'..files_parser, 'repo', '' },
+    '--dissociate',
+    '--remote-submodules', '--no-remote-submodules',
+    { opteq=true, '--separate-git-dir='..dirs_parser },
+    flagex_c_config,
+    flagex__config,
+    flagex__depthdepth,
+    { opteq=true, '--shallow-since='..shallow_since_arg, 'date', '' },
+    { opteq=true, '--shallow-exclude='..placeholder_required_arg, 'rev', '' },
+    '--single-branch', '--no-single-branch',
+    '--no-tags',
+    '--recurse-submodules',
+    { '--recurse-submodules='..files_parser, 'pathspec', '' },
+    '--shallow-submodules', '--no-shallow-submodules',
+    { '-j'..placeholder_required_arg, ' n', '' },
+    { opteq=true, '--jobs'..placeholder_required_arg, ' n', '' },
+})
+
+local commit_parser = parser()
+:_addexflags({
+    "-a", "--all",
+    "-p", "--patch",
+    { "-C"..placeholder_required_arg, " commit", "" },
+    { opteq=true, "--reuse-message="..placeholder_required_arg, "commit", "" },
+    { "-c"..placeholder_required_arg, " commit", "" },
+    { opteq=true, "--reedit-message="..placeholder_required_arg, "commit", "" },
+    { opteq=true, "--fixup="..parser({'amend:', 'reword:'}) },
+    { opteq=true, "--squash="..placeholder_required_arg, 'commit', '' },
+    "--reset-author",
+    "--short",
+    "--branch",
+    "--porcelain",
+    "--long",
+    "-z",
+    "--null",
+    { "-F"..files_parser, " file", "" },
+    { opteq=true, "--file="..files_parser, "file", "" },
+    { opteq=true, "--author="..person_arg },
+    { opteq=true, "--date="..placeholder_required_arg, "date", "" },
+    { "-m"..placeholder_required_arg, " msg", "" },
+    { opteq=true, "--message="..placeholder_required_arg, "msg", "" },
+    { "-t"..files_parser, " file", "" },
+    { opteq=true, "--template="..files_parser, "file", "" },
+    "-s", "--signoff", "--no-signoff",
+    { opteq=true, "--trailer"..commit_trailer_arg, " token[:value]", "" },
+    --"--verify",
+    "-n", "--no-verify",
+    "--allow-empty",
+    "--allow-empty-message",
+    flagex__cleanupequals,
+    "-e", "--edit", "--no-edit",
+    "--amend",
+    "--no-post-rewrite",
+    "-i", "--include",
+    "-o", "--only",
+    '--pathspec-from-file='..files_parser,
+    '--pathspec-file-nul',
+    "-u", "-uno", "-uall", "--untracked-files", "--untracked-files="..untracked_files_arg,
+    "-v", "--verbose",
+    "-q", "--quiet",
+    "--dry-run",
+    "--status",
+    "--no-status",
+    "-S", "--gpg-sign",
+    flagex__gpgsignequals,
+    "--no-gpg-sign",
+    "--",
+})
+
+local config_parser = parser()
+:addarg(git_options)
+:_addexflags({
+    "--replace-all",
+    "--add",
+    "--get",
+    "--get-all",
+    "--get-regexp",
+    { opteq=true, "--get-urlmatch"..placeholder_required_arg, " name URL", "" },
+    "--global",
+    "--system",
+    "--local",
+    "--worktree",
+    { "-f"..files_parser, " config-file", "" },
+    { opteq=true, "--file"..files_parser, " config-file", "" },
+    { opteq=true, "--blob"..placeholder_required_arg, " blob", "" },
+    "--remove-section",
+    "--rename-section",
+    "--unset",
+    "--unset-all",
+    "-l", "--list",
+    "--fixed-value",
+    { opteq=true, "--type="..parser({"bool", "int", "bool-or-int", "path", "expiry-date", "color"}) },
+    "--no-type",
+    --"--bool",
+    --"--int",
+    --"--bool-or-int",
+    --"--path",
+    --"--expiry-date",
+    "-z", "--null",
+    "--name-only",
+    "--show-origin",
+    "--show-scope",
+    { opteq=true, "--get-color"..placeholder_required_arg, " name [default]", "" },
+    { opteq=true, "--get-colorbool"..placeholder_required_arg, " name", "" },
+    "-e", "--edit",
+    "--includes", "--no-includes",
+    { opteq=true, "--default"..placeholder_required_arg, " value", "" },
+})
+
+local diff_parser = parser()
+:addarg(local_or_remote_branches, file_matches)
+:_addexflags(diff_flags)
+
+local difftool_parser = parser()
+:_addexflags({
+    '-d', '--dir-diff',
+    '-y', '--no-prompt', '--prompt',
+    '--rotate-to='..files_parser,
+    '--skip-to='..files_parser,
+    '-t', '--tool='..placeholder_required_arg, -- TODO: complete tool (take from config)
+    '--tool-help',
+    '--symlinks', '--no-symlinks',
+    { '-x'..difftool_extcmd_arg, ' command', '' },
+    { '--extcmd='..difftool_extcmd_arg, ' command', '' },
+    '-g', '--gui', '--no-gui',
+    '--trust-exit-code', '--no-trust-exit-code',
+})
+
+local fetch_parser = parser()
+:addarg(remotes)
+:_addexflags({
+    '--write-fetch-head', '--no-write-fetch-head',
+    '--multiple',
+    '--auto-maintenance', '--no-auto-maintenance',
+    --'--auto-gc', '--no-auto-gc',
+    '--no-write-commit-graph',
+    '-P', '--prune-tags',
+    '-n', '--no-tags',
+    '--recurse-submodules',
+    '--recurse-submodules='..parser({'yes', 'on-demand', 'no'}),
+    '--no-recurse-submodules',
+    { opteq=true, '--submodule-prefix='..placeholder_required_arg, 'prefix', '' },
+    --'--recurse-submodules-default='..parser({'yes', 'on-demand'}),
+    '-u', '--update-head-ok',
+    '-q', '--quiet',
+    '-v', '--verbose',
+    '--stdin',
+})
+:_addexflags(fetch_flags)
+
+local help_parser = parser()
+:_addexflags({
+    { "-a",                             "Print all available commands" },
+    { "--all",                          "Print all available commands" },
+    --"--verbose",
+    { "-c",                             "List all available config variables" },
+    { "--config",                       "List all available config variables" },
+    { "-g",                             "Print a list of git concept guides" },
+    { "--guides",                       "Print a list of git concept guides" },
+    --"-i",
+    --"--info",
+    { "-m",                             "Display manual page for the command in the man format" },
+    { "--man",                          "Display manual page for the command in the man format" },
+    { "-w",                             "Display manual page for the command in HTML format" },
+    { "--web",                          "Display manual page for the command in HTML format" },
+})
+if help_parser.setdelayinit then
+    help_parser:addarg({delayinit=function (argmatcher)
+        local matches = all_commands() or {}
+        local guides = concept_guides() or {}
+        for _,g in ipairs(guides) do
+            table.insert(matches, g)
+        end
+        return matches
+    end})
+else
+    help_parser:addarg(concept_guides, all_commands)
+end
+
+local log_parser = parser()
+:_addexflags(log_flags)
+:_addexflags(log_history_flags)
+:_addexflags(diff_flags)
+:_addexflags(commit_formatting_flags)
+
+local merge_parser = parser()
+:addarg(branches)
+:_addexflags({
+    "--commit", "--no-commit",
+    "--edit", "-e", "--no-edit",
+    flagex__cleanupequals,
+    "--ff", "--no-ff", "--ff-only",
+    "--log", "--no-log",
+    { "--log="..placeholder_required_arg, "n", "" },
+    "--signoff", "--no-signoff",
+    "--squash", "--no-squash",
+    "--summary", "--no-summary",
+    "--allow-unrelated-histories",
+    { "-m"..placeholder_required_arg, ' message', '' },
+    { opteq=true, "--into-name"..parser({branches}), ' branch', '' },
+    { "-F"..files_parser, ' file', '' },
+    { opteq=true, "--file="..files_parser, 'file', '' },
+    "--overwrite-ignore", "--no-overwrite-ignore",
+})
+:_addexflags(merge_flags_common)
+:_addexflags(merge_flags)
+
+local pull_parser = parser()
+:addarg(remotes)
+:addarg(branches)
+:_addexflags({
+    "-q", "--quiet",
+    "-v", "--verbose",
+    "--recurse-submodules",
+    "--recurse-submodules="..parser({'yes', 'on-demand', 'no'}),
+    "--no-recurse-submodules",
+        -- Options related to merging...
+    "--commit", "--no-commit",
+    "-e", "--edit", "--no-edit",
+    flagex__cleanupequals,
+    "--ff", "--no-ff", "--ff-only",
+    "--log", "--no-log",
+    { "--log="..placeholder_required_arg, "n", "" },
+    "--signoff", "--no-signoff",
+    "--squash", "--no-squash",
+    "--summary", "--no-summary",
+    "--allow-unrelated-histories",
+    "-r", "--no-rebase",
+    { opteq=true, "--rebase="..parser({'false', 'true', 'merges', 'interactive'}) },
+})
+:_addexflags(merge_flags_common)
+:_addexflags(fetch_flags)
+
+local push_parser = parser()
+:addarg(remotes)
+:addarg(push_branch_spec)
+:_addexflags({
+    '--all',
+    '--prune',
+    '--mirror',
+    '-n', '--dry-run',
+    '--porcelain',
+    '-d', '--delete',
+    '--tags',
+    '--follow-tags',
+    '--signed', '--signed='..parser({'true', 'false', 'if-asked'}), '--no-signed',
+    '--atomic', '--no-atomic',
+    --'-o'..placeholder_required_arg, '--server-option='..placeholder_required_arg,
+    { opteq=true, '--receive-pack='..receive_pack_arg, 'git-receive-pack', '' },
+    { opteq=true, '--exec='..receive_pack_arg, 'git-receive-pack', '' },
+    '--force-with-lease', '--no-force-with-lease',
+    { '--force-with-lease='..placeholder_required_arg, 'refname[:expect]', '' },
+    '-f', '--force',
+    '--force-if-includes', '--no-force-if-includes',
+    { opteq=true, '--repo='..repo_arg },
+    '-u', '--set-upstream',
+    '--thin', '--no-thin',
+    '-q', '--quiet',
+    '-v', '--verbose',
+    --'--progress',
+    '--no-recurse-submodules',
+    { opteq=true, '--recurse-submodules='..parser({'check', 'on-demand', 'only', 'no'}) },
+    --'--verify',
+    '--no-verify',
+    '-4', '--ipv4',
+    '-6', '--ipv6',
+})
+
+local rebase_parser = parser()
+:addarg(local_or_remote_branches)
+:addarg(branches)
+:_addexflags({
+    { opteq=true, '--onto' .. parser({branches}), ' newbase', '' },
+    '--keep-base',
+    '--continue',
+    '--abort',
+    '--quit',
+    '--apply',
+    { opteq=true, '--empty='..parser({'drop', 'keep', 'ask'}) },
+    '--keep-empty', '--no-keep-empty',
+    '--reapply-chery-picks', '--no-reapply-chery-picks',
+    '--allow-empty-message',
+    '--skip',
+    '--edit-todo',
+    '--show-current-patch',
+    '-m', '--merge',
+    { '-C', 'n', '' },
+    '--no-ff',
+    '-f', '--force-rebase',
+    '--fork-point', '--no-fork-point',
+    '--ignore-whitespace',
+    flag__whitespaceequals,
+    '--committer-date-is-author-date',
+    '--ignore-date', '--reset-author-date',
+    '--signoff',
+    '-r', { opteq=true, '--rebase-merges='..parser({'rebase-cousins', 'no-rebase-cousins'}) },
+    { '-x'..x_cmd_arg, ' command', '' },
+    { opteq=true, '--exec='..x_cmd_arg, 'command', '' },
+    '--root',
+    '--autosquash', '--no-autosquash',
+    '--reschedule-failed-exec', '--no-reschedule-failed-exec',
+})
+:_addexflags(merge_flags_common)
+:_addexflags(merge_flags)
+
+local remote_parser = parser()
+:addarg(
+    "add" ..parser(
+        "-t"..parser({branches}),
+        "-m"..placeholder_required_arg,
+        "-f",
+        "--mirror="..parser({"fetch", "push"}),
+        "--tags", "--no-tags"
+    ),
+    "rename"..parser({remotes}),
+    "remove"..parser({remotes}),
+    "rm"..parser({remotes}),
+    "set-head"..parser({remotes}, {branches},
+        "-a", "--auto",
+        "-d", "--delete"
+    ),
+    "set-branches"..parser("--add", {remotes}, {branches}),
+    "get-url"..parser({remotes}, "--push", "--all"),
+    "set-url"..parser(
+        "--add"..parser("--push", {remotes}),
+        "--delete"..parser("--push", {remotes})
+    ),
+    "show"..parser("-n", {remotes}),
+    "prune"..parser("-n", "--dry-run", {remotes}),
+    "update"..parser({remotes}, "-p", "--prune")
+)
+:addflags(
+    "-v",
+    "--verbose"
 )
 
-local merge_recursive_options = parser({
-    "ours",
-    "theirs",
-    "renormalize",
-    "no-renormalize",
-    "diff-algorithm="..parser({
-        "patience",
-        "minimal",
-        "histogram",
-        "myers"
+local reset_parser = parser()
+:addarg(local_or_remote_branches)   -- TODO: Add commit completions
+:_addexflags({
+    "-q",
+    "-p", "--patch",
+    { opteq=true, "--pathspec-from-file="..files_parser }, --"--stdin",
+    "--pathspec-file-nul", --"-z",
+    "--soft", "--mixed", "--hard",
+    "--merge", "--keep", "--no-recurse-submodules"
+})
+
+local restore_parser = parser()
+:addarg(file_matches)
+:_addexflags({
+    "-s", "--source",
+    "-p", "--patch",
+    "-W", "--worktree",
+    "-S", "--staged",
+    "-q", "--quiet",
+    --"--progress",
+    "--no-progress",
+    "--ours", "--theirs",
+    "-m", "--merge",
+    flag__conflictequals,
+    "--ignore-unmerged",
+    "--ignore-skip-worktree-bits",
+    "--recurse-submodules", "--no-recurse-submodules",
+    "--overlay",
+     --"--no-overlay",
+    { opteq=true, "--pathspec-from-file="..files_parser },
+    "--pathspec-file-nul"
+})
+
+local revert_parser = parser()
+:_addexflags({
+    "-e", "--edit",
+    "-m", "--mainline",
+    "--no-edit",
+    flagex__cleanupequals,
+    "-n", "--no-commit",
+    "-S", "--gpg-sign",
+    "--no-gpg-sign",
+    "-s", "--signoff",
+    flagex__strategy,
+    flagex_X_strategyoption,
+    flagex__strategyoption,
+    "--rerere-autoupdate",
+    "--no-rerere-autoupdate",
+    "--continue",
+    "--skip",
+    "--quit",
+    "--abort",
+})
+
+local show_parser = parser()
+:_addexflags(diff_flags)
+:_addexflags(commit_formatting_flags)
+
+local stash_parser = parser()
+:addarg(
+    "push"..parser():_addexflags({
+        "-p", "--patch",
+        "-S", "--staged",
+        "-k", "--no-keep-index", "--keep-index",
+        "-u", "--include-untracked",
+        "-a", "--all",
+        "-q", "--quiet",
+        { "-m"..placeholder_required_arg, " message", "" },
+        { opteq=true, "--message"..placeholder_required_arg, " message", "" },
+        { opteq=true, "--pathspec-from-file="..files_parser },
+        "--pathspec-file-nul",
     }),
-    "patience",
-    "ignore-space-change",
-    "ignore-all-space",
-    "ignore-space-at-eol",
-    "rename-threshold=",
-    -- "subtree="..parser(),
-    "subtree"
-})
-
-local merge_strategies = parser({
-    "resolve",
-    "recursive",
-    "ours",
-    "octopus",
-    "subtree"
-})
-
-local cleanup_options = parser({
-    "strip",
-    "whitespace",
-    "verbatim",
-    "scissors",
-    "default"
-})
-
-local git_parser = parser(
-    {
-        {alias},
-        "add" .. parser({matchers.files},
-            "-n", "--dry-run",
-            "-v", "--verbose",
-            "-f", "--force",
-            "-i", "--interactive",
-            "-p", "--patch",
-            "-e", "--edit",
-            "-u", "--update",
-            "-A", "--all",
-            "--no-all",
-            "--ignore-removal",
-            "--no-ignore-removal",
-            "-N", "--intent-to-add",
-            "--refresh",
-            "--ignore-errors",
-            "--ignore-missing"
-            ),
-        "add--interactive",
-        "am",
-        "annotate" .. parser({matchers.files},
-            "-b",
-            "--root",
-            "--show-stats",
-            "-L",
-            "-l",
-            "-t",
-            "-S",
-            "--reverse",
-            "-p",
-            "--porcelain",
-            "--line-porcelain",
-            "--incremental",
-            "--encoding=",
-            "--contents",
-            "--date",
-            "-M",
-            "-C",
-            "-h"
-            ),
-        "apply" .. parser(
-            "--stat",
-            "--numstat",
-            "--summary",
-            "--check",
-            "--index",
-            "--cached",
-            "-3", "--3way",
-            "--build-fake-ancestor=",
-            "-R", "--reverse",
-            "--reject",
-            "-z",
-            "-p",
-            "-C",
-            "--unidiff-zero",
-            "--apply",
-            "--no-add",
-            "--allow-binary-replacement", "--binary",
-            "--exclude=",
-            "--include=",
-            "--ignore-space-change", "--ignore-whitespace",
-            "--whitespace=",
-            "--inaccurate-eof",
-            "-v", "--verbose",
-            "--recount",
-            "--directory="
-            ),
-        "archive",
-        "bisect",
-        "bisect--helper",
-        "blame",
-        "branch" .. parser(
-            "-v", "--verbose",
-            "-q", "--quiet",
-            "-t", "--track",
-            "--set-upstream",
-            "-u", "--set-upstream-to",
-            "--unset-upstream",
-            "--color",
-            "-r", "--remotes",
-            "--contains" ,
-            "--abbrev",
-            "-a", "--all",
-            "-d" .. parser({branches}):loop(1),
-            "--delete" .. parser({branches}):loop(1),
-            "-D" .. parser({branches}):loop(1),
-            "-m", "--move",
-            "-M",
-            "--list",
-            "-l", "--create-reflog",
-            "--edit-description",
-            "-f", "--force",
-            "--no-merged",
-            "--merged",
-            "--column"
-        ),
-        "bundle",
-        "cat-file",
-        "check-attr",
-        "check-ignore",
-        "check-mailmap",
-        "check-ref-format",
-        "checkout" .. parser({checkout_spec_generator},
-            "-q", "--quiet",
-            "-b",
-            "-B",
-            "-l",
-            "--detach",
-            "-t", "--track",
-            "--orphan",
-            "-2", "--ours",
-            "-3", "--theirs",
-            "-f", "--force",
-            "-m", "--merge",
-            "--overwrite-ignore",
-            "--conflict",
-            "-p", "--patch",
-            "--ignore-skip-worktree-bits"
-        ),
-        "checkout-index",
-        "cherry",
-        "cherry-pick"..parser(
-            "-e", "--edit",
-            "-m", "--mainline ",
-            "-n", "--no-commit",
-            "-r",
-            "-x",
-            "--ff",
-             "-s", "-S", "--gpg-sign",
-            "--allow-empty",
-            "--allow-empty-message",
-            "--keep-redundant-commits",
-            "--strategy"..parser({merge_strategies}),
-            "-X"..parser({merge_recursive_options}),
-            "--strategy-option"..parser({merge_recursive_options}),
-            "--continue",
-            "--quit",
-            "--abort"
-        ),
-        "citool",
-        "clean",
-        "clone" .. parser(
-            "--template",
-            "-l", "--local",
-            "-s", "--shared",
-            "--no-hardlinks",
-            "-q", "--quiet",
-            "-n", "--no-checkout",
-            "--bare",
-            "--mirror",
-            "-o", "--origin",
-            "-b", "--branch",
-            "-u", "--upload-pack",
-            "--reference",
-            "--dissociate",
-            "--separate-git-dir",
-            "--depth",
-            "--single-branch", "--no-single-branch",
-            "--no-tags",
-            "--recurse-submodules", "--shallow-submodules", "--no-shallow-submodules",
-            "--jobs"
-        ),
-        "column",
-        "commit" .. parser(
-            "-a", "--all",
-            "-p", "--patch",
-            "-C", "--reuse-message=",
-            "-c", "--reedit-message=",
-            "--fixup=",
-            "--squash=",
-            "--reset-author",
-            "--short",
-            "--branch",
-            "--porcelain",
-            "--long",
-            "-z",
-            "--null",
-            "-F", "--file=",
-            "--author=",
-            "--date=",
-            "-m", "--message=",
-            "-t", "--template=",
-            "-s", "--signoff",
-            "-n", "--no-verify",
-            "--allow-empty",
-            "--allow-empty-message",
-            "--cleanup"..cleanup_options,
-            "-e", "--edit",
-            "--no-edit",
-            "--amend",
-            "--no-post-rewrite",
-            "-i", "--include",
-            "-o", "--only",
-            "-u", "--untracked-files", "--untracked-files=", -- .. parser({"no", "normal", "all"}),
-            "-v", "--verbose",
-            "-q", "--quiet",
-            "--dry-run",
-            "--status",
-            "--no-status",
-            "-S", "--gpg-sign", "--gpg-sign=",
-            "--"
-        ),
-        "commit-tree",
-        "config"..config_parser,
-        "count-objects",
-        "credential",
-        "credential-store",
-        "credential-wincred",
-        "daemon",
-        "describe",
-        "diff" .. parser({local_or_remote_branches, matchers.files}),
-        "diff-files",
-        "diff-index",
-        "diff-tree",
-        "difftool"..parser(
-            "-d", "--dir-diff",
-            "-y", "--no-prompt", "--prompt",
-            "-t", "--tool=" -- TODO: complete tool (take from config)
-        ),
-        "difftool--helper",
-        "fast-export",
-        "fast-import",
-        "fetch" .. parser({remotes},
-            "--all",
-            "--prune",
-            "--tags"
-        ),
-        "fetch-pack",
-        "filter-branch",
-        "fmt-merge-msg",
-        "for-each-ref",
-        "format-patch",
-        "fsck",
-        "fsck-objects",
-        "gc",
-        "get-tar-commit-id",
-        "grep",
-        "gui",
-        "gui--askpass",
-        "gui--askyesno",
-        "gui.tcl",
-        "hash-object",
-        "help",
-        "http-backend",
-        "http-fetch",
-        "http-push",
-        "imap-send",
-        "index-pack",
-        "init",
-        "init-db",
-        "log",
-        "lost-found",
-        "ls-files",
-        "ls-remote",
-        "ls-tree",
-        "mailinfo",
-        "mailsplit",
-        "merge" .. parser({branches},
-            "--commit", "--no-commit",
-            "--edit", "-e", "--no-edit",
-            "--ff", "--no-ff", "--ff-only",
-            "--log", "--no-log",
-            "--stat", "-n", "--no-stat",
-            "--squash", "--no-squash",
-            "-s" .. merge_strategies,
-            "--strategy" .. merge_strategies,
-            "-X" .. merge_recursive_options,
-            "--strategy-option" .. merge_recursive_options,
-            "--verify-signatures", "--no-verify-signatures",
-            "-q", "--quiet", "-v", "--verbose",
-            "--progress", "--no-progress",
-            "-S", "--gpg-sign",
-            "-m",
-            "--rerere-autoupdate", "--no-rerere-autoupdate",
-            "--abort"
-        ),
-        "merge-base",
-        "merge-file",
-        "merge-index",
-        "merge-octopus",
-        "merge-one-file",
-        "merge-ours",
-        "merge-recursive",
-        "merge-resolve",
-        "merge-subtree",
-        "merge-tree",
-        "mergetool",
-        "mergetool--lib",
-        "mktag",
-        "mktree",
-        "mv",
-        "name-rev",
-        "notes",
-        "p4",
-        "pack-objects",
-        "pack-redundant",
-        "pack-refs",
-        "parse-remote",
-        "patch-id",
-        "peek-remote",
-        "prune",
-        "prune-packed",
-        "pull" .. parser(
-            {remotes}, {branches},
-            "-q", "--quiet",
-            "-v", "--verbose",
-            "--recurse-submodules", --[no-]recurse-submodules[=yes|on-demand|no]
-            "--no-recurse-submodules",
-            "--commit", "--no-commit",
-            "-e", "--edit", "--no-edit",
-            "--ff", "--no-ff", "--ff-only",
-            "--log", "--no-log",
-            "--stat", "-n", "--no-stat",
-            "--squash", "--no-squash",
-            "-s"..merge_strategies,
-            "--strategy"..merge_strategies,
-            "-X"..merge_recursive_options,
-            "--strategy-option"..merge_recursive_options,
-            "--verify-signatures", "--no-verify-signatures",
-            "--summary", "--no-summary",
-            "-r", "--rebase", "--no-rebase",
-            "--all",
-            "-a", "--append",
-            "--depth", "--unshallow", "--update-shallow",
-            "-f", "--force",
-            "-k", "--keep",
-            "--no-tags",
-            "-u", "--update-head-ok",
-            "--upload-pack",
-            "--progress"
-        ),
-        "push" .. parser(
-            {remotes},
-            {push_branch_spec},
-            "-v", "--verbose",
-            "-q", "--quiet",
-            "--repo",
-            "--all",
-            "--mirror",
-            "--delete",
-            "--tags",
-            "-n", "--dry-run",
-            "--porcelain",
-            "-f", "--force",
-            "--force-with-lease",
-            "--recurse-submodules",
-            "--thin",
-            "--receive-pack",
-            "--exec",
-            "-u", "--set-upstream",
-            "--progress",
-            "--prune",
-            "--no-verify",
-            "--follow-tags"
-        ),
-        "quiltimport",
-        "read-tree",
-        "rebase" .. parser({local_or_remote_branches}, {branches},
-            "-i", "--interactive",
-            "--onto" .. parser({branches}),
-            "--continue",
-            "--abort",
-            "--keep-empty",
-            "--skip",
-            "--edit-todo",
-            "-m", "--merge",
-            "-s" .. merge_strategies,
-            "--strategy"..merge_strategies,
-            "-X" .. merge_recursive_options,
-            "--strategy-option"..merge_recursive_options,
-            "-S", "--gpg-sign",
-            "-q", "--quiet",
-            "-v", "--verbose",
-            "--stat", "-n", "--no-stat",
-            "--no-verify", "--verify",
-            "-C",
-            "-f", "--force-rebase",
-            "--fork-point", "--no-fork-point",
-            "--ignore-whitespace", "--whitespace",
-            "--committer-date-is-author-date", "--ignore-date",
-            "-i", "--interactive",
-            "-p", "--preserve-merges",
-            "-x", "--exec",
-            "--root",
-            "--autosquash", "--no-autosquash",
-            "--autostash", "--no-autostash",
-            "--no-ff"
-            ),
-        "receive-pack",
-        "reflog",
-        "remote"..parser({
-            "add" ..parser(
-                "-t"..parser({branches}),
-                "-m",
-                "-f",
-                "--mirror",
-                "--tags", "--no-tags"
-            ),
-            "rename"..parser({remotes}),
-            "remove"..parser({remotes}),
-            "rm"..parser({remotes}),
-            "set-head"..parser({remotes}, {branches},
-                "-a", "--auto",
-                "-d", "--delete"
-            ),
-            "set-branches"..parser("--add", {remotes}, {branches}),
-            "set-url"..parser(
-                "--add"..parser("--push", {remotes}),
-                "--delete"..parser("--push", {remotes})
-            ),
-            "get-url"..parser({remotes}, "--push", "--all"),
-            "show"..parser("-n", {remotes}),
-            "prune"..parser("-n", "--dry-run", {remotes}),
-            "update"..parser({remotes}, "-p", "--prune")
-            }, "-v", "--verbose"),
-        "remote-ext",
-        "remote-fd",
-        "remote-ftp",
-        "remote-ftps",
-        "remote-hg",
-        "remote-http",
-        "remote-https",
-        "remote-testsvn",
-        "repack",
-        "replace",
-        "repo-config",
-        "request-pull",
-        "rerere",
-        -- TODO: Add commit completions
-        "reset"..parser({local_or_remote_branches},
-            "-q",
-            "-p", "--patch",
-            "--soft", "--mixed", "--hard",
-            "--merge", "--keep"
-            ),
-        "restore"..parser({matchers.files},
-            "-s", "--source",
-            "-p", "--patch",
-            "-W", "--worktree",
-            "-S", "--staged",
-            "-q", "--quiet",
-            "--progress", "--no-progress",
-            "--ours", "--theirs",
-            "-m", "--merge",
-            "--conflict",
-            "--ignore-unmerged",
-            "--ignore-skip-worktree-bits",
-            "--overlay", "--no-overlay"
-        ),
-        "rev-list",
-        "rev-parse",
-        "revert"..parser(
-            "-e", "--edit",
-            "-m", "--mainline",
-            "--no-edit",
-            "--cleanup"..cleanup_options,
-            "-n", "--no-commit",
-            "-S", "--gpg-sign",
-            "--no-gpg-sign",
-            "-s", "--signoff",
-            "--strategy"..merge_strategies,
-            "-X"..merge_recursive_options,
-            "--strategy-option"..merge_recursive_options,
-            "--rerere-autoupdate",
-            "--no-rerere-autoupdate",
-            "--continue",
-            "--skip",
-            "--quit",
-            "--abort"
-        ),
-        "rm",
-        "send-email",
-        "send-pack",
-        "sh-i18n",
-        "sh-i18n--envsubst",
-        "sh-setup",
-        "shortlog",
-        "show",
-        "show-branch",
-        "show-index",
-        "show-ref",
-        "stage",
-        "stash"..parser({
-            "list", -- TODO: The command takes options applicable to the git log
-                    -- command to control what is shown and how it's done
-            "show"..parser({stashes}),
-            "drop"..parser({stashes}, "-q", "--quiet"),
-            "pop"..parser({stashes}, "--index", "-q", "--quiet"),
-            "apply"..parser({stashes}, "--index", "-q", "--quiet"),
-            "branch"..parser({branches}, {stashes}),
-            "save"..parser(
-                "-p", "--patch",
-                "-k", "--no-keep-index", "--keep-index",
-                "-q", "--quiet",
-                "-u", "--include-untracked",
-                "-a", "--all"
-                ),
-            "clear"
-            }),
-        "status",
-        "stripspace",
-        "submodule"..parser({
-            "add",
-            "init",
-            "deinit",
-            "foreach",
-            "status"..parser("--cached", "--recursive"),
-            "summary",
-            "sync",
-            "update"
-        }, '--quiet'),
-        "subtree",
-        "switch"..parser({local_or_remote_branches},
-            "-c", "-C", "--create",
-            "--force-create",
-            "-d", "--detach",
-            "--guess", "--no-guess",
-            "-f", "--force", "--discard-changes",
-            "-m", "--merge",
-            "--conflict",
-            "-q", "--quiet",
-            "--progress", "--no-progress",
-            "-t", "--track",
-            "--no-track",
-            "--orphan",
-            "--ignore-other-worktrees",
-            "--recurse-submodules", "--no-recurse-submodules"
-        ),
-        "svn"..parser({
-            "init"..parser("-T", "--trunk", "-t", "--tags", "-b", "--branches", "-s", "--stdlayout",
-                "--no-metadata", "--use-svm-props", "--use-svnsync-props", "--rewrite-root",
-                "--rewrite-uuid", "--username", "--prefix"..parser({"origin"}), "--ignore-paths",
-                "--include-paths", "--no-minimize-url"),
-                "fetch"..parser({remotes}, "--localtime", "--parent", "--ignore-paths", "--include-paths",
-                "--log-window-size"),
-                "clone"..parser("-T", "--trunk", "-t", "--tags", "-b", "--branches", "-s", "--stdlayout",
-                "--no-metadata", "--use-svm-props", "--use-svnsync-props", "--rewrite-root",
-                "--rewrite-uuid", "--username", "--prefix"..parser({"origin"}), "--ignore-paths",
-                "--include-paths", "--no-minimize-url", "--preserve-empty-dirs",
-                "--placeholder-filename"),
-                "rebase"..parser({local_or_remote_branches}, {branches}),
-            "dcommit"..parser("--no-rebase", "--commit-url", "--mergeinfo", "--interactive"),
-            "branch"..parser("-m","--message","-t", "--tags", "-d", "--destination",
-                             "--username", "--commit-url", "--parents"),
-            "log"..parser("-r", "--revision", "-v", "--verbose", "--limit",
-                          "--incremental", "--show-commit", "--oneline"),
-            "find-rev"..parser("--before", "--after"),
-            "reset"..parser("-r", "--revision", "-p", "--parent"),
-            "tag",
-            "blame",
-            "set-tree",
-            "create-ignore",
-            "show-ignore",
-            "mkdirs",
-            "commit-diff",
-            "info",
-            "proplist",
-            "propget",
-            "show-externals",
-            "gc"
-        }),
-        "symbolic-ref",
-        "tag",
-        "tar-tree",
-        "unpack-file",
-        "unpack-objects",
-        "update-index",
-        "update-ref",
-        "update-server-info",
-        "upload-archive",
-        "upload-pack",
-        "var",
-        "verify-pack",
-        "verify-tag",
-        "web--browse",
-        "whatchanged",
-        "worktree"..parser({
-            "add"..parser(
-                {matchers.dirs},
-                {branches},
-                "-f", "--force",
-                "--detach",
-                "--checkout",
-                "--lock",
-                "-b"..parser({branches})
-            ),
-            "list"..parser("--porcelain"),
-            "lock"..parser("--reason"),
-            "move",
-            "prune"..parser(
-                "-n", "--dry-run",
-                "-v", "--verbose",
-                "--expire"
-            ),
-            "remove"..parser("-f"),
-            "unlock"
-        }),
-        "write-tree",
-    },
-    "--version",
-    "--help",
-    "-c",
-    "--exec-path",
-    "--html-path",
-    "--man-path",
-    "--info-path",
-    "-p", "--paginate", "--no-pager",
-    "--no-replace-objects",
-    "--bare",
-    "--git-dir=",
-    "--work-tree=",
-    "--namespace="
+    --[["save"..parser(
+        "-p", "--patch",
+        "-k", "--no-keep-index", "--keep-index",
+        "-q", "--quiet",
+        "-u", "--include-untracked",
+        "-a", "--all"
+        ),]]
+    "list"..parser():_addexflags(commit_formatting_flags):_addexflags(diff_flags):_addexflags(log_flags),
+    "show"..parser({stashes}, "-u", "--include-untracked", "--only-untracked"):_addexflags(diff_flags),
+    "pop"..parser({stashes}, "--index", "-q", "--quiet"),
+    "apply"..parser({stashes}, "--index", "-q", "--quiet"),
+    "branch"..parser({branches}, {stashes}),
+    "clear",
+    "drop"..parser({stashes}, "-q", "--quiet")
 )
+
+local status_parser = parser()
+:_addexflags({
+    '-s', '--short',
+    '-b', '--branch',
+    '--show-stash',
+    '--porcelain', '--porcelain='..parser({'v1', 'v2'}),
+    --'--long',
+    '-v', '--verbose',
+    '-u', '-uno', '-uall', '--untracked-files', '--untracked-files='..untracked_files_arg,
+    "--ignore-submodules",
+    flag__ignore_submodules,
+    '--ignored',
+    '--ignored='..parser({'traditional', 'no', 'matching'}),
+    '-z',
+    '--column', '--no-column',
+    flag__columnequals,
+    '--ahead-behind', '--no-ahead-behind',
+    '--renames', '--no-renames',
+    --'--lock-index', '--no-lock-index',
+    --'--find-renames='..placeholder_required_arg,
+    { '-M', 'n', '' },
+    '--find-renames',
+    { '--find-renames='..placeholder_required_arg, 'n', '' },
+})
+
+local submodule_parser = parser()
+:_addexarg({
+    'add'..parser():_addexflags({
+        { '-b'..placeholder_required_arg, ' branch', '' },
+        '-f', '--force',
+        { opteq=true, '--name'..placeholder_required_arg, ' name', '' },
+        { opteq=true, '--reference'..placeholder_required_arg, ' repo_url', '' },
+        { opteq=true, '--depth'..placeholder_required_arg, ' depth', '' },
+    }),
+    'status'..parser('--cached', '--recursive'),
+    'init',
+    'deinit'..parser('-f', '--force', '--all'),
+    'update'..parser():_addexflags({
+        '--init',
+        '--remote',
+        '-N', '--no-fetch',
+        '--recommend-shallow', '--no-recommend-shallow',
+        '-f', '--force',
+        '--checkout', '--rebase', '--merge',
+        { opteq=true, '--reference'..placeholder_required_arg, ' repo_url', '' },
+        { opteq=true, '--depth'..placeholder_required_arg, ' depth', '' },
+        '--recursive',
+        { opteq=true, '--jobs'..placeholder_required_arg, ' n', '' },
+        '--single-branch', '--no-single-branch',
+    }),
+    'set-branch'..parser():_addexflags({
+        { '-b'..placeholder_required_arg, ' branch', '' },
+        { opteq=true, '--branch'..placeholder_required_arg, ' branch', '' },
+        '-d', '--default',
+    }),
+    'set-url'..parser():addarg(file_matches):addarg(placeholder_required_arg):nofiles(),
+    'summary'..parser():_addexflags({
+        '--cached',
+        '--files',
+        { '-n'..summary_limit_arg, ' n', '' },
+        { opteq=true, '--summary-limit'..summary_limit_arg, ' n', '' },
+    }),
+    { 'foreach'..parser('--recursive'):addarg({fromhistory=true}), ' shell_command', '' },
+    'sync'..parser('--recursive'),
+    'absorbgitdirs',
+})
+:addflags('--quiet')
+
+local svn_parser = parser()
+:addarg(
+    "init"..parser("-T", "--trunk", "-t", "--tags", "-b", "--branches", "-s", "--stdlayout",
+        "--no-metadata", "--use-svm-props", "--use-svnsync-props", "--rewrite-root",
+        "--rewrite-uuid", "--username", "--prefix"..parser({"origin"}), "--ignore-paths",
+        "--include-paths", "--no-minimize-url"),
+        "fetch"..parser({remotes}, "--localtime", "--parent", "--ignore-paths", "--include-paths",
+        "--log-window-size"),
+        "clone"..parser("-T", "--trunk", "-t", "--tags", "-b", "--branches", "-s", "--stdlayout",
+        "--no-metadata", "--use-svm-props", "--use-svnsync-props", "--rewrite-root",
+        "--rewrite-uuid", "--username", "--prefix"..parser({"origin"}), "--ignore-paths",
+        "--include-paths", "--no-minimize-url", "--preserve-empty-dirs",
+        "--placeholder-filename"),
+        "rebase"..parser({local_or_remote_branches}, {branches}),
+    "dcommit"..parser("--no-rebase", "--commit-url", "--mergeinfo", "--interactive"),
+    "branch"..parser("-m","--message","-t", "--tags", "-d", "--destination",
+                     "--username", "--commit-url", "--parents"),
+    "log"..parser("-r", "--revision", "-v", "--verbose", "--limit",
+                  "--incremental", "--show-commit", "--oneline"),
+    "find-rev"..parser("--before", "--after"),
+    "reset"..parser("-r", "--revision", "-p", "--parent"),
+    "tag",
+    "blame",
+    "set-tree",
+    "create-ignore",
+    "show-ignore",
+    "mkdirs",
+    "commit-diff",
+    "info",
+    "proplist",
+    "propget",
+    "show-externals",
+    "gc"
+)
+
+local switch_parser = parser()
+:addarg(local_or_remote_branches)
+:_addexflags({
+    { '-c'..placeholder_required_arg, ' new-branch', '' },
+    { opteq=true, '--create'..placeholder_required_arg, ' new-branch', '' },
+    { '-C'..placeholder_required_arg, ' new-branch', '' },
+    { opteq=true, '--force-create'..placeholder_required_arg, ' new-branch', '' },
+    '-d', '--detach',
+    '--guess', '--no-guess',
+    '-f', '--force', '--discard-changes',
+    '-m', '--merge',
+    flag__conflictequals,
+    '-q', '--quiet',
+    --'--progress',
+    '--no-progress',
+    '-t', '--track', '--track='..parser({'direct', 'inherit'}), '--no-track',
+    { opteq=true, '--orphan'..placeholder_required_arg, ' new-branch', '' },
+    '--ignore-other-worktrees',
+    '--recurse-submodules', '--no-recurse-submodules',
+})
+
+local worktree_parser = parser()
+:addarg(
+    "add"..parser(
+        {dir_matches},
+        {branches}
+    ):_addexflags({
+        "-f", "--force",
+        "--detach",
+        "--checkout",
+        "--lock",
+        { opteq=true, "--reason"..placeholder_required_arg, " string", "" },
+        { "-b"..parser({branches}), " new-branch", "" },
+    }),
+    "list"..parser("-v", "--porcelain"),
+    "lock"..parser():_addexflags({
+        { opteq=true, "--reason"..placeholder_required_arg, " string", "" },
+    }),
+    "move",
+    "prune"..parser():_addexflags({
+        "-n", "--dry-run",
+        "-v", "--verbose",
+        { "--expire", " expire", "" },
+    }),
+    "remove"..parser("-f", "--force"),
+    "unlock"
+)
+
+--------------------------------------------------------------------------------
+-- The main git command parser.
+
+local git_parser = parser()
+:_addexarg({
+    nosort=true,
+    { "add"..add_parser,                    "Add file contents to the index" },
+    { "annotate"..blame_parser,             "Annotate file lines with commit information" },
+    { "apply"..apply_parser,                "Apply a patch to files and/or to the index" },
+    { "blame"..blame_parser,                "Show last modify info for lines of a file" },
+    { "branch"..branch_parser,              "List, create, or delete branches" },
+    { "cat-file"..catfile_parser,           "Provide content or type and size info for repo objects" },
+    { "checkout"..checkout_parser,          "Switch branches or restore working tree files" },
+    { "cherry-pick"..cherrypick_parser,     "Apply changes introduced by some existing commits" },
+    { "clone"..clone_parser,                "Clone a repository into a new directory" },
+    { "commit"..commit_parser,              "Record changes to the repository" },
+    { "config"..config_parser,              "Get and set repository or global options" },
+    { "diff"..diff_parser,                  "Show changes between commits, trees, tags, etc" },
+    { "difftool"..difftool_parser,          "Show changes using common diff tools" },
+    { "fetch"..fetch_parser,                "Download objects and refs from another repository" },
+    { "help"..help_parser,                  "Print help on a command or topic" },
+    { "log"..log_parser,                    "Show commit logs" },
+    { "merge"..merge_parser,                "Join two or more development histories together" },
+    { "pull"..pull_parser,                  "Fetch from and integrate with another repo or local branch" },
+    { "push"..push_parser,                  "Update remote refs along with associated objects" },
+    { "rebase"..rebase_parser,              "Reapply commits on top of another base tip" },
+    { "remote"..remote_parser,              "Manage set of tracked repositories" },
+    { "reset"..reset_parser,                "Reset current HEAD to the specified state" },
+    { "restore"..restore_parser,            "Restore working tree files" },
+    { "revert"..revert_parser,              "Revert some existing commits" },
+    { "show"..show_parser,                  "Show various types of objects" },
+    { "stash"..stash_parser,                "Stash the changes in a dirty working directory away" },
+    { "status"..status_parser,              "Show the working tree status" },
+    { "submodule"..submodule_parser,        "Initialize, update or inspect submodules" },
+    { "switch"..switch_parser,              "Switch branches" },
+    { "worktree"..worktree_parser,          "Manage multiple working trees" },
+    alias,                                  -- Aliases for commands.
+    "add--interactive",
+    "am",
+    "archive",
+    "bisect",
+    "bisect--helper",
+    "bundle",
+    "check-attr",
+    "check-ignore",
+    "check-mailmap",
+    "check-ref-format",
+    "checkout-index",
+    "cherry",
+    "citool",
+    "clean",
+    "column",
+    "commit-tree",
+    "count-objects",
+    "credential",
+    "credential-store",
+    "credential-wincred",
+    "daemon",
+    "describe",
+    "diff-files",
+    "diff-index",
+    "diff-tree",
+    "difftool--helper",
+    "fast-export",
+    "fast-import",
+    "fetch-pack",
+    "filter-branch",
+    "fmt-merge-msg",
+    "for-each-ref",
+    "format-patch",
+    "fsck",
+    "fsck-objects",
+    "gc",
+    "get-tar-commit-id",
+    "grep",
+    "gui",
+    "gui--askpass",
+    "gui--askyesno",
+    "gui.tcl",
+    "hash-object",
+    "http-backend",
+    "http-fetch",
+    "http-push",
+    "imap-send",
+    "index-pack",
+    "init",
+    "init-db",
+    "lost-found",
+    "ls-files",
+    "ls-remote",
+    "ls-tree",
+    "mailinfo",
+    "mailsplit",
+    "merge-base",
+    "merge-file",
+    "merge-index",
+    "merge-octopus",
+    "merge-one-file",
+    "merge-ours",
+    "merge-recursive",
+    "merge-resolve",
+    "merge-subtree",
+    "merge-tree",
+    "mergetool",
+    "mergetool--lib",
+    "mktag",
+    "mktree",
+    "mv",
+    "name-rev",
+    "notes",
+    "p4",
+    "pack-objects",
+    "pack-redundant",
+    "pack-refs",
+    "parse-remote",
+    "patch-id",
+    "peek-remote",
+    "prune",
+    "prune-packed",
+    "quiltimport",
+    "read-tree",
+    "receive-pack",
+    "reflog",
+    "remote-ext",
+    "remote-fd",
+    "remote-ftp",
+    "remote-ftps",
+    "remote-hg",
+    "remote-http",
+    "remote-https",
+    "remote-testsvn",
+    "repack",
+    "replace",
+    "repo-config",
+    "request-pull",
+    "rerere",
+    "rev-list",
+    "rev-parse",
+    "rm",
+    "send-email",
+    "send-pack",
+    "sh-i18n",
+    "sh-i18n--envsubst",
+    "sh-setup",
+    "shortlog",
+    "show-branch",
+    "show-index",
+    "show-ref",
+    "stage",
+    "stripspace",
+    "subtree",
+    "svn"..svn_parser,
+    "symbolic-ref",
+    "tag",
+    "tar-tree",
+    "unpack-file",
+    "unpack-objects",
+    "update-index",
+    "update-ref",
+    "update-server-info",
+    "upload-archive",
+    "upload-pack",
+    "var",
+    "verify-pack",
+    "verify-tag",
+    "web--browse",
+    "whatchanged",
+    "write-tree",
+})
+:_addexflags({
+    { "--version",                          "Print the git suite version" },
+    { "--help"..help_parser, " [...]",      "Print general help, or help on a topic" },
+    { "-C"..dirs_parser, " path",           "Run as if git was started in PATH" },
+    { "-c"..placeholder_required_arg, " name=value", "Pass a configuration parameter, overriding config files" },
+    { "--exec-path",                        "Print where the core git programs are stored" },
+    { "--exec-path="..dirs_parser, "path",  "Override path to the core git programs" },
+    { "--html-path",                        "Print where git's HTML documentation is stored" },
+    --"--man-path",
+    --"--info-path",
+    { "-p",                                 "Pipe all output into less" },
+    { "--paginate",                         "Pipe all output into less" },
+    { "--no-pager",                         "Do not pipe git output into a pager" },
+    { "--no-replace-objects",               "Do not use replacement refs to replace git objects" },
+    { "--bare",                             "Treat the repository as a bare repository" },
+    { "--git-dir="..dirs_parser, "path",    "Set the path to the repo ('.git' directory)" },
+    { "--work-tree="..dirs_parser, "path",  "Set the path to the working tree" },
+    { "--namespace="..placeholder_required_arg, "path", "Set the git namespace" },
+    { "--literal-pathspecs",                "Treat pathspecs literally (no globbing, magic, etc)" },
+    { "--glob-pathspecs",                   "Apply 'glob' magic to all pathspecs" },
+    { "--no-glob-pathspecs",                "Add 'literal' magic to all pathspecs" },
+    { "--icase-pathspecs",                  "Add 'icase' magic to all pathspecs" },
+    { "--no-optional-locks",                "Do not perform optional operations that require locks" },
+})
 
 clink.arg.register_parser("git", git_parser)

--- a/git.lua
+++ b/git.lua
@@ -6,6 +6,10 @@ local matchers = require('matchers')
 local w = require('tables').wrap
 local parser = clink.arg.new_parser
 
+if (clink.version_encoded or 0) >= 10010009 then
+    settings.add('color.git.star', 'bright green', 'Color for preferred branch completions')
+end
+
 ---
  -- Lists remote branches based on packed-refs file from git directory
  -- @param string [dir]  Directory where to search file for
@@ -156,11 +160,17 @@ local function checkout_spec_generator(token)
     --     since it is not added automatically by readline (see previous point)
     clink.matches_are_files(0)
     clink.match_display_filter = function ()
+        local pre = ''
+        local suf = ''
+        if (clink.version_encoded or 0) >= 10010009 and rl.isvariabletrue('colored-stats') then
+            pre = '\x1b['..settings.get('color.git.star')..'m'
+            suf = '\x1b['..settings.get('color.filtered')..'m'
+        end
         return files:map(function(file)
             return clink.is_dir(file) and file..'\\' or file
         end)
         :concat(local_branches)
-        :concat(predicted_branches:map(function(branch) return '*'..branch end))
+        :concat(predicted_branches:map(function(branch) return pre..'*'..suf..branch end))
         :concat(remote_branches)
     end
 

--- a/git.lua
+++ b/git.lua
@@ -82,12 +82,21 @@ local function alias(token)
     local f = io.popen("git config --get-regexp alias 2>nul")
     if f == nil then return {} end
 
-    for line in f:lines() do
-        local s = line:find(" ", 1, true)
-        local alias_name = line:sub(7, s - 1)
-        local start = alias_name:find(token, 1, true)
-        if start and start == 1 then
-            table.insert(res, alias_name)
+    if clink_version.supports_display_filter_description then
+        for line in f:lines() do
+            local name, command = line:match("^alias.([^ ]+) +(.+)$")
+            if name then
+                table.insert(res, { match=name, description="Alias: "..command })
+            end
+        end
+    else
+        for line in f:lines() do
+            local s = line:find(" ", 1, true)
+            local alias_name = line:sub(7, s - 1)
+            local start = alias_name:find(token, 1, true)
+            if start and start == 1 then
+                table.insert(res, alias_name)
+            end
         end
     end
 

--- a/modules/arghelper.lua
+++ b/modules/arghelper.lua
@@ -1,0 +1,233 @@
+--------------------------------------------------------------------------------
+-- Helpers to make it easy to add descriptions in argmatchers.
+--
+--      argmatcher:_addexflags()
+--      argmatcher:_addexarg()
+--
+-- These accept the following format:
+--
+--      local a = clink.argmatcher()
+--
+--      a:_addexflags({
+--          some_function,                  -- Adds some_function.
+--          "-a",                           -- Adds match "-a".
+--          { "-b" },                       -- Adds match "-b".
+--          { "-c", "Use colors" },         -- Adds match "-c" and description "Use colors".
+--          { "-d", " date",  "List newer than date" }, -- Adds string "-d", arginfo " date", and description "List newer than date".
+--          {                               -- Nested table, following the same format.
+--              { "-e" },
+--              { "-f" },
+--          },
+--      })
+--
+-- Both _addexflags() and _addexarg() accept the same input format.
+--
+-- This also fills in compatibility methods for any of the following argmatcher
+-- methods that may be missing in older versions of Clink.  This makes backward
+-- compatibility much easier, because your code can
+--
+--      argmatcher:addarg()
+--      argmatcher:addflags()
+--      argmatcher:nofiles()
+--      argmatcher:adddescriptions()
+--      argmatcher:hideflags()
+--      argmatcher:setflagsanywhere()
+--      argmatcher:setendofflags()
+
+if not clink then
+    -- E.g. some unit test systems will run this module *outside* of Clink.
+    return
+end
+
+local tmp = clink.argmatcher and clink.argmatcher() or clink.arg.new_parser()
+local meta = getmetatable(tmp)
+local interop = {}
+
+if not tmp.addarg then
+    interop.addarg = function(parser, ...)
+        -- Extra braces to make sure exactly one argument position is added.
+        parser:add_arguments({...})
+        return parser
+    end
+end
+
+if not tmp.addflags then
+    interop.addflags = function(parser, ...)
+        parser:add_flags(...)
+        return parser
+    end
+end
+
+if not tmp.nofiles then
+    interop.nofiles = function(parser)
+        parser:disable_file_matching()
+        return parser
+    end
+end
+
+if not tmp.adddescriptions then
+    interop.adddescriptions = function(parser)
+        return parser
+    end
+end
+
+if not tmp.hideflags then
+    interop.hideflags = function(parser)
+        return parser
+    end
+end
+
+if not tmp.setflagsanywhere then
+    interop.setflagsanywhere = function(parser)
+        return parser
+    end
+end
+
+if not tmp.setendofflags then
+    interop.setendofflags = function(parser)
+        return parser
+    end
+end
+
+if not tmp._addexflags or not tmp._addexarg then
+    local link = "link"..tmp
+    local meta_link = getmetatable(link)
+
+    local function is_parser(x)
+        return getmetatable(x) == meta
+    end
+
+    local function is_link(x)
+        return getmetatable(x) == meta_link
+    end
+
+    local function add_elm(elm, list, descriptions, hide)
+        local arg
+        local opteq
+        if elm[1] then
+            arg = elm[1]
+            opteq = elm.opteq and is_link(arg)
+        else
+            if type(elm) == "table" and not is_link(elm) and not is_parser(elm) then
+                return
+            end
+            arg = elm
+        end
+
+        local t = type(arg)
+        if is_link(arg) or is_parser(arg) then
+            t = "matcher"
+        elseif t == "table" then
+            if elm[4] then
+                t = "nested"
+            else
+                for _,scan in ipairs(elm) do
+                    if type(scan) == "table" then
+                        t = "nested"
+                        break
+                    end
+                end
+            end
+        end
+        if t == "string" or t == "number" or t == "matcher" then
+            if t == "matcher" then
+                table.insert(list, arg)
+                if opteq and clink.argmatcher then
+                    local altkey
+                    if arg._key:sub(-1) == '=' then
+                        altkey = arg._key:sub(1, #arg._key - 1)
+                    else
+                        altkey = arg._key..'='
+                    end
+                    table.insert(hide, altkey)
+                    table.insert(list, { altkey..arg._matcher })
+                end
+            else
+                table.insert(list, tostring(arg))
+            end
+            if elm[2] and descriptions then
+                local name = is_link(arg) and arg._key or arg
+                if elm[3] then
+                    descriptions[name] = { elm[2], elm[3] }
+                else
+                    descriptions[name] = { elm[2] }
+                end
+            end
+        elseif t == "function" then
+            table.insert(list, arg)
+        elseif t == "nested" then
+            for _,sub_elm in ipairs(elm) do
+                add_elm(sub_elm, list, descriptions, hide)
+            end
+        else
+            pause("unrecognized input table format.")
+            error("unrecognized input table format.")
+        end
+    end
+
+    local function build_lists(tbl)
+        local list = {}
+        local descriptions = (not ARGHELPER_DISABLE_DESCRIPTIONS) and {}
+        local hide = {}
+        if type(tbl) ~= "table" then
+            pause('table expected.')
+            error('table expected.')
+        end
+        for _,elm in ipairs(tbl) do
+            local t = type(elm)
+            if t == "table" then
+                add_elm(elm, list, descriptions, hide)
+            elseif t == "string" or t == "number" or t == "function" then
+                table.insert(list, elm)
+            end
+        end
+        list.fromhistory = tbl.fromhistory
+        list.nosort = tbl.nosort
+        return list, descriptions, hide
+    end
+
+    if not tmp._addexflags then
+        interop._addexflags = function(parser, tbl)
+            local flags, descriptions, hide = build_lists(tbl)
+            parser:addflags(flags)
+            if descriptions then
+                parser:adddescriptions(descriptions)
+            end
+            if hide then
+                parser:hideflags(hide)
+            end
+            return parser
+        end
+    end
+    if not tmp._addexarg then
+        interop._addexarg = function(parser, tbl)
+            local args, descriptions = build_lists(tbl)
+            parser:addarg(args)
+            if descriptions then
+                parser:adddescriptions(descriptions)
+            end
+            return parser
+        end
+    end
+end
+
+-- If nothing was missing, then no interop functions got added, and the meta
+-- table doesn't need to be modified.
+for _,_ in pairs(interop) do
+    local old_index = meta.__index
+    meta.__index = function(parser, key)
+        local value = rawget(interop, key)
+        if value then
+            return value
+        elseif not old_index then
+            return rawget(parser, key)
+        elseif type(old_index) == "function" then
+            return old_index(parser, key)
+        elseif old_index == meta then
+            return rawget(old_index, key)
+        else
+            return old_index[key]
+        end
+    end
+    break
+end

--- a/modules/arghelper.lua
+++ b/modules/arghelper.lua
@@ -24,7 +24,8 @@
 --
 -- This also fills in compatibility methods for any of the following argmatcher
 -- methods that may be missing in older versions of Clink.  This makes backward
--- compatibility much easier, because your code can
+-- compatibility much easier, because your code can use newer APIs and they'll
+-- just do nothing if the version of Clink in use doesn't actually support them.
 --
 --      argmatcher:addarg()
 --      argmatcher:addflags()

--- a/modules/clink_version.lua
+++ b/modules/clink_version.lua
@@ -6,8 +6,13 @@ clink = clink or {}
 
 local clink_version_encoded = clink.version_encoded or 0
 
+-- Version check for the new v1.0.0 API redesign.
+exports.new_api = (settings and settings.add and true or false)
+
+-- Version checks for specific features.
 exports.supports_display_filter_description = (clink_version_encoded >= 10010012)
 exports.supports_color_settings = (clink_version_encoded >= 10010009)
 exports.supports_query_rl_var = (clink_version_encoded >= 10010009)
+exports.supports_path_toparent = (clink_version_encoded >= 10010020)
 
 return exports

--- a/modules/gitutil.lua
+++ b/modules/gitutil.lua
@@ -42,7 +42,7 @@ exports.get_git_dir = function (start_dir)
     return has_git_dir(start_dir)
         or has_git_file(start_dir)
         -- Otherwise go up one level and make a recursive call
-        or (parent_path ~= start_dir and exports.get_git_dir(parent_path) or nil)
+        or (parent_path ~= '' and parent_path ~= start_dir and exports.get_git_dir(parent_path) or nil)
 end
 
 exports.get_git_common_dir = function (start_dir)

--- a/modules/matchers.lua
+++ b/modules/matchers.lua
@@ -1,3 +1,4 @@
+local clink_version = require('clink_version')
 
 local exports = {}
 
@@ -34,6 +35,11 @@ exports.dirs = function(word)
 end
 
 exports.files = function (word)
+    if clink_version.supports_display_filter_description then
+        local matches = w(clink.filematches(word))
+        return matches
+    end
+
     -- Strip off any path components that may be on text.
     local prefix = ""
     local i = word:find("[\\/:][^\\/:]*$")

--- a/modules/path.lua
+++ b/modules/path.lua
@@ -1,6 +1,11 @@
 local exports = {}
 
 local w = require('tables').wrap
+local clink_version = require('clink_version')
+
+local function isdir(name)
+    return clink_version.new_api and os.isdir(name) or clink.is_dir(name)
+end
 
 exports.list_files = function (base_path, glob, recursive, reverse_separator)
     local mask = glob or '/*'
@@ -11,7 +16,7 @@ exports.list_files = function (base_path, glob, recursive, reverse_separator)
     end)
 
     local files = entries:filter(function(entry)
-        return not clink.is_dir(base_path..'/'..entry)
+        return not isdir(base_path..'/'..entry)
     end)
 
     -- if 'recursive' flag is not set, we don't need to iterate
@@ -22,7 +27,7 @@ exports.list_files = function (base_path, glob, recursive, reverse_separator)
 
     return entries
     :filter(function(entry)
-        return clink.is_dir(base_path..'/'..entry)
+        return isdir(base_path..'/'..entry)
     end)
     :reduce(files, function(accum, dir)
         -- iterate through directories and call list_files recursively
@@ -34,26 +39,45 @@ exports.list_files = function (base_path, glob, recursive, reverse_separator)
     end)
 end
 
-exports.basename = function (path)
-    local prefix = path
-    local i = path:find("[\\/:][^\\/:]*$")
-    if i then
-        prefix = path:sub(i + 1)
+exports.basename = function (pathname)
+    local prefix = pathname
+    if clink_version.supports_path_toparent then
+        prefix = path.getname(pathname)
+    else
+        local i = pathname:find("[\\/:][^\\/:]*$")
+        if i then
+            prefix = pathname:sub(i + 1)
+        end
     end
     return prefix
 end
 
-exports.pathname = function (path)
+exports.pathname = function (pathname)
     local prefix = ""
-    local i = path:find("[\\/:][^\\/:]*$")
-    if i then
-        prefix = path:sub(1, i-1)
+    if clink_version.supports_path_toparent then
+        -- Clink v1.1.20 and higher provide an API to do this right.
+        local child
+        prefix,child = path.toparent(pathname)
+        if child == "" then
+            -- This means it can't go up further.  The old implementation
+            -- returned "" in that case, though no callers stopped when an
+            -- empty path was returned; they only stopped when the
+            -- returned path equaled the input path.
+            prefix = ""
+        end
+    else
+        -- This approach has several bugs. For example, "c:/" yields "c".
+        -- Walking up looking for .git tries "c:/.git" and then "c/.git".
+        local i = pathname:find("[\\/:][^\\/:]*$")
+        if i then
+            prefix = pathname:sub(1, i-1)
+        end
     end
     return prefix
 end
 
-exports.is_absolute = function (path)
-    local drive = path:find("^%s?[%l%a]:[\\/]")
+exports.is_absolute = function (pathname)
+    local drive = pathname:find("^%s?[%l%a]:[\\/]")
     if drive then return true else return false end
 end
 

--- a/net.lua
+++ b/net.lua
@@ -1,36 +1,84 @@
-local parser = clink.arg.new_parser
-local net_parser = parser(
-    {
-        "accounts" .. parser("/forcelogoff:", "/forcelogoff:no", "/domain",
-                             "/maxpwage:", "/maxpwage:unlimited", "/minpwage:",
-                             "/minpwlen:","/uniquepw:"),
-        "computer" .. parser({"*" .. parser("/add", "/del")}),
-        "config" .. parser({"server", "workstation"}),
-        "continue",
-        "file",
-        "group",
-        "helpmsg",
-        "localgroup",
-        "pause",
-        "session" .. parser({parser("/delete", "/list")}),
-        "share",
-        "start",
-        "statistics" .. parser({"server", "workstation"}),
-        "stop",
-        "time" .. parser("/domain", "/rtsdomain", "/set"),
-        "use" .. parser("/user:", "/smartcard", "/savecred", "/delete",
-                       "/persistent:yes", "/persistent:no"),
-        "user",
-        "view" .. parser("/cache", "/all", "/domain")
-    },
-    "/?"
-)
+local clink_version = require('clink_version')
 
-local help_parser = parser(
-    {
-        "help" .. parser({net_parser:flatten_argument(1), "names", "services", "syntax"})
-    }
-)
+local function args(...)
+    if clink_version.new_api then
+        return clink.argmatcher()
+            :addflags("/?")
+            :addarg(...)
+            :addarg()
+            :nofiles()
+            :loop()
+    else
+        return clink.arg.new_parser({...}, "/?")
+    end
+end
 
-clink.arg.register_parser("net", net_parser)
-clink.arg.register_parser("net", help_parser)
+local function flags(...)
+    if clink_version.new_api then
+        return clink.argmatcher()
+            :addflags("/?", ...)
+            :addarg({})
+            :loop()
+    else
+        return clink.arg.new_parser("/?", ...)
+    end
+end
+
+local function flagsnofiles(...)
+    if clink_version.new_api then
+        return flags(...):nofiles()
+    else
+        return clink.arg.new_parser({}, "/?", ...)
+    end
+end
+
+local helpflag = flagsnofiles()
+
+local time_parser
+if clink_version.new_api then
+    time_parser = clink.argmatcher()
+        :addflags("/domain", "/domain:", "/rtsdomain", "/rtsdomain:", "/set", "/?")
+        :addarg({})
+        :loop()
+else
+    time_parser = flags("/domain", "/rtsdomain", "/set", "/?")
+end
+
+local net_table =
+{
+    "accounts" .. flags("/forcelogoff:", "/forcelogoff:no", "/domain",
+                        "/maxpwage:", "/maxpwage:unlimited", "/minpwage:",
+                        "/minpwlen:","/uniquepw:"),
+    "computer" .. args("*" .. flagsnofiles("/add", "/del")),
+    "config" .. args("server", "workstation"),
+    "continue" .. helpflag,
+    "file" .. helpflag,
+    "group" .. helpflag,
+    "helpmsg" .. helpflag,
+    "localgroup" .. helpflag,
+    "pause" .. helpflag,
+    "session" .. flags("/delete", "/list"),
+    "share" .. helpflag,
+    "start" .. helpflag,
+    "statistics" .. args("server", "workstation"),
+    "stop" .. helpflag,
+    "time" .. time_parser,
+    "use" .. flags("/user:", "/smartcard", "/savecred", "/delete",
+                   "/persistent:yes", "/persistent:no"),
+    "user" .. helpflag,
+    "view" .. flags("/cache", "/all", "/domain")
+}
+
+local help_table =
+{
+    "help" .. args(net_table, "names", "services", "syntax")
+}
+
+if clink_version.new_api then
+    clink.argmatcher("net")
+    :addflags("/?")
+    :addarg(net_table, help_table)
+else
+    clink.arg.register_parser("net", clink.arg.new_parser(net_table), "/?")
+    clink.arg.register_parser("net", clink.arg.new_parser(help_table))
+end

--- a/scoop.lua
+++ b/scoop.lua
@@ -9,13 +9,16 @@ local w = require("tables").wrap
 local concat = require("funclib").concat
 
 local parser = clink.arg.new_parser
-local profile = os.getenv("home") or os.getenv("USERPROFILE")
+
+local function get_home_dir()
+    return os.getenv("home") or os.getenv("USERPROFILE")
+end
 
 local function scoop_folder()
     local folder = os.getenv("SCOOP")
 
     if not folder then
-        folder = profile .. "\\scoop"
+        folder = get_home_dir() .. "\\scoop"
     end
 
     return folder
@@ -32,7 +35,7 @@ local function scoop_global_folder()
 end
 
 local function scoop_load_config() -- luacheck: no unused args
-    local file = io.open(profile .. "\\.config\\scoop\\config.json")
+    local file = io.open(get_home_dir() .. "\\.config\\scoop\\config.json")
     -- If there is no such file, then close handle and return
     if file == nil then
         return w()


### PR DESCRIPTION
Ugh!  Even after rebasing and recreating the branch multiple times, I still haven't figured out to successfully get the PR to only show the new changes.  I guess I'm not understanding how to create topic branches for the purpose of pull requests into an upstream base repository.  Clearly `git pull --all` followed by `git merge master` and `git switch -c new_branch` is not the right way.

Well, the commits I'm sending the PR for are the ones from July 8.

This PR rolls up a year or so of enhancements and updating the scripts to use new Clink features when available.

This PR includes the following:
- Uses new Clink APIs when available; this improves robustness of the path manipulation routines, for example.
- Fixes a performance issue when looking for the git repo dir; it tried to go up past the drive root, and attempting to use an empty string as a directory.
- The scoop parser gets the home directory more optimally now.
- Minor enhancements in the net parser.
- Enhancements when displaying push branch completions.
- Enhancements when displaying checkout branch completions.
- Major update to the git parser:
  - It uses new Clink APIs when available (and modules\arghelper.lua includes a shim layer that greatly simplifies backward compatibility all the way back to v0.4.9).
  - Provides completions for help topics.
  - Updated flag parsers for many commands.
  - Added flag parsers for some commands.
  - The "main" commands now show descriptions when generating completions for command names.
  - Command aliases now support the same parsing and coloring as the aliased commands.
  - The code is rearranged to help facilitate adding more descriptions in the future.