### PR TITLE
Support wireless adb devices completation

### DIFF
--- a/completions/adb.lua
+++ b/completions/adb.lua
@@ -41,7 +41,7 @@ local function generate_matches(command, pattern)
 end
 
 local function serialno_matches()
-    return generate_matches('adb devices', '^(%w+)%s+.*$')
+    return generate_matches('adb devices', '^([%w:%.]+)%s+.*$')
 end
 
 local function transportid_matches()

--- a/completions/adb.lua
+++ b/completions/adb.lua
@@ -41,7 +41,7 @@ local function generate_matches(command, pattern)
 end
 
 local function serialno_matches()
-    return generate_matches('adb devices', '^([%w:%.]+)%s+.*$')
+    return generate_matches('adb devices', '^([%w:.]+)%s+.*$')
 end
 
 local function transportid_matches()

--- a/completions/scrcpy.lua
+++ b/completions/scrcpy.lua
@@ -42,7 +42,7 @@ local function generate_matches(command, pattern)
 end
 
 local function serialno_matches()
-    return generate_matches('adb devices', '^([%w:%.]+)%s+.*$')
+    return generate_matches('adb devices', '^([%w:.]+)%s+.*$')
 end
 
 local serialno_parser = clink.argmatcher():addarg({serialno_matches})

--- a/completions/scrcpy.lua
+++ b/completions/scrcpy.lua
@@ -42,7 +42,7 @@ local function generate_matches(command, pattern)
 end
 
 local function serialno_matches()
-    return generate_matches('adb devices', '^(%w+)%s+.*$')
+    return generate_matches('adb devices', '^([%w:%.]+)%s+.*$')
 end
 
 local serialno_parser = clink.argmatcher():addarg({serialno_matches})


### PR DESCRIPTION
If you have a wireless adb device, the format is:
```
List of devices attached
192.168.1.176:35063     device
```
So I've modified the regex from `'^(%w+)%s+.*$'` to `^([%w:%.]+)%s+.*$'`