### PR TITLE
Update `eza` and fix long options missing help text.

### DIFF
--- a/completions/eza.lua
+++ b/completions/eza.lua
@@ -15,104 +15,112 @@ clink.argmatcher("eza")
 :_addexflags({
     -- META OPTIONS
     { "-?",                             "show help" },
-    { "--help" },
+    { "--help",                         "show help" },
     { "-v",                             "show version of eza" },
-    { "--version" },
+    { "--version",                      "show version of eza" },
 
     -- DISPLAY OPTIONS
     { "-1",                             "display one entry per line" },
-    { "--oneline" },
+    { "--oneline",                      "display one entry per line" },
     { "-l",                             "display extended file metadata as a table" },
-    { "--long" },
+    { "--long",                         "display extended file metadata as a table" },
     { "-G",                             "display entries as a grid (default)" },
-    { "--grid" },
+    { "--grid",                         "display entries as a grid (default)" },
     { "-x",                             "sort the grid across, rather than downwards" },
-    { "--across" },
+    { "--across",                       "sort the grid across, rather than downwards" },
     { "-R",                             "recurse into directories" },
-    { "--recurse" },
+    { "--recurse",                      "recurse into directories" },
     { "-T",                             "recurse into directories as a tree" },
-    { "--tree" },
+    { "--tree",                         "recurse into directories as a tree" },
     { "-X",                             "dereference symbolic links when displaying information" },
-    { "--dereference" },
+    { "--dereference",                  "dereference symbolic links when displaying information" },
     { "-F",                             "display type indicator by file names" },
+    { "--classify",                     "display type indicator by file names" },
     { "-F="..when, "WHEN",              "when to display type indicator by file names" },
-    { "--classify" },
-    { "--classify="..when, "WHEN", "" },
-    { "--color" },                          --"use terminal colors"
-    { "--color="..when, "WHEN", "" },       --"when to use terminal colors"
+    { "--classify="..when, "WHEN",      "when to display type indicator by file names" },
+    { "--color",                        "use terminal colors" },
+    { "--color="..when, "WHEN",         "when to use terminal colors" },
     { hide=true, "--colour" },
     { hide=true, "--colour="..when },
-    { "--color-scale" },                    --"highlight levels of all fields distinctly"
-    { "--color-scale="..field, "FIELD", "" }, --"highlight levels of FIELD distinctly"
+    { "--color-scale",                  "highlight levels of all fields distinctly" },
+    { "--color-scale="..field, "FIELD", "highlight levels of FIELD distinctly" },
     { hide=true, "--colour-scale" },
     { hide=true, "--colour-scale="..field },
-    { opteq=true, "--color-scale-mode="..mode, "MODE", "" }, --"use gradient or fixed colors in --color-scale"
+    { opteq=true, "--color-scale-mode="..mode, "MODE", "use gradient or fixed colors in --color-scale" },
     { hide=true, opteq=true, "--colour-scale-mode="..mode },
-    { "--icons" },                          --"display icons"
-    { "--icons="..when, "WHEN", "" },       --"when to display icons"
-    { "--no-quotes" },                      --"don't quote file names with spaces"
-    { "--hyperlink" },                      --"display entries as hyperlinks"
-    { opteq=true, "-w="..cols, "COLS",      "set screen width in columns" },
+    { "--icons",                        "display icons" },
+    { "--icons="..when, "WHEN",         "when to display icons" },
+    { "--no-quotes",                    "don't quote file names with spaces" },
+    { "--hyperlink",                    "display entries as hyperlinks" },
+    { "--follow-symlinks",              "drill down into symbolic links that point to directories" },
+    { "--absolute",                     "display entries with their absolute path" },
+    { opteq=true, "-w="..cols, "COLS",  "set screen width in columns" },
     { hide=true, "-w"..cols },
-    { opteq=true, "--width="..cols, "COLS", "" }, --"set screen width in columns"
+    { opteq=true, "--width="..cols, "COLS", "set screen width in columns" },
     { hide=true, "--width"..cols },
 
     -- FILTERING AND SORTING OPTIONS
     { "-a",                             "show hidden and 'dot' files" },
-    { "--all" },
+    { "--all",                          "show hidden and 'dot' files" },
     { "-aa",                            "also show the '.' and '..' directories" },
     { hide=true, "-A" },                    --"equivalent to --all; included for compatibility with `ls -A`"
     { hide=true, "--almost-all" },
     { "-d",                             "list directories as files; don't list their contents" },
-    { "--list-dirs" },
-    { opteq=true, "-L"..levels, " DEPTH", "limit the depth of recursion" },
-    { opteq=true, "--level="..levels, "DEPTH", "" },
+    { "--list-dirs",                    "list directories as files; don't list their contents" },
+    { opteq=true, "-L"..levels, " DEPTH",      "limit the depth of recursion" },
+    { opteq=true, "--level="..levels, "DEPTH", "limit the depth of recursion" },
     { "-r",                             "reverse the sort order" },
-    { "--reverse" },
-    { opteq=true, "-s="..sortfield, "SORT_FIELD", "which field to sort by" },
-    { opteq=true, "--sort="..sortfield, "SORT_FIELD", "" },
-    { "--group-directories-first" },        --"list directories before other files"
+    { "--reverse",                      "reverse the sort order" },
+    { opteq=true, "-s="..sortfield, "SORT_FIELD",     "which field to sort by" },
+    { opteq=true, "--sort="..sortfield, "SORT_FIELD", "which field to sort by" },
+    { "--group-directories-first",      "list directories before other files" },
+    { "--group-directories-last",       "list directories after other files" },
     { "-D",                             "list only directories" },
-    { "--only-dirs" },
+    { "--only-dirs",                    "list only directories" },
     { "-f",                             "list only files" },
-    { "--only-files" },
+    { "--only-files",                   "list only files" },
+    { "--show-symlinks",                "explicitly show symbolic links (for use with --only-dirs | --only-files)" },
+    { "--no-symlinks",                  "do not show symbolic links" },
     -- -I, --ignore-glob GLOBS          glob patterns (pipe-separated) of files to ignore
-    { "--git-ignore" },                     --"ignore files mentioned in '.gitignore'"
+    { "--git-ignore",                   "ignore files mentioned in '.gitignore'" },
 
     -- LONG VIEW OPTIONS
     { "-b",                             "list file sizes with binary prefixes" },
-    { "--binary" },
+    { "--binary",                       "list file sizes with binary prefixes" },
     { "-B",                             "list file sizes in bytes, without any prefixes" },
-    { "--bytes" },
+    { "--bytes",                        "list file sizes in bytes, without any prefixes" },
     -- -g, --group                      list each file's group
     -- --smart-group                    only show group if it has a different name from owner
     { "-h",                             "add a header row to each column" },
-    { "--header" },
+    { "--header",                       "add a header row to each column" },
     -- -H, --links                      list each file's number of hard links
     -- -i, --inode                      list each file's inode number
     -- -m, --modified                   use the modified timestamp field
     -- -M, --mounts                     show mount details (Linux and Mac only)
     -- -n, --numeric                    list numeric user and group IDs
     { "-O",                             "list file flags (Mac, BSD, and Windows only)" },
-    { "--flags" },
+    { "--flags",                        "list file flags (Mac, BSD, and Windows only)" },
     { "-S",                             "show size of allocated file system blocks" },
-    { "--blocksize" },
+    { "--blocksize",                    "show size of allocated file system blocks" },
     { opteq=true, "-t"..timefield, " FIELD", "which timestamp field to list" },
     { opteq=true, "--time="..timefield, "FIELD", "" },
+    { "-m",                             "use the modified timestamp field" },
+    { "--modified",                     "use the modified timestamp field" },
     { "-u",                             "use the accessed timestamp field" },
-    { "--accessed" },
+    { "--accessed",                     "use the accessed timestamp field" },
     { "-U",                             "use the created timestamp field" },
-    { "--created" },
-    { "--changed" },
+    { "--created",                      "use the created timestamp field" },
+    { "--changed",                      "use the changed timestamp field" },
     { opteq=true, "--time-style="..timestyles, "STYLE", "how to format timestamps" },
     -- --total-size                     show the size of a directory as the size of all files and directories inside (unix only)
-    { "--no-permissions" },
+    { "--no-permissions",               "suppress the permissions field" },
     -- -o, --octal-permissions          list each file's permission in octal format
-    { "--no-filesize" },
+    { "--no-filesize",                  "suppress the filesize field" },
     -- --no-user                        suppress the user field
-    { "--no-time" },
+    { "--no-time",                      "suppress the time field" },
     -- --stdin                          read file names from stdin, one per line or other separator specified in environment
-    { "--git" },                            --"list each file's Git status, if tracked or ignored"
-    { "--no-git" },                         --"suppress Git status"
-    { "--git-repos" },                      --"list root of git-tree status"
+    { "--git",                          "list each file's Git status, if tracked or ignored" },
+    { "--no-git",                       "suppress Git status" },
+    { "--git-repos",                    "list root of git-tree status" },
+    { "--git-repos-no-status",          "list each git-repos branch name (much faster)" },
 })


### PR DESCRIPTION
I've added some options that are new in `eza`.

The help text was missing in the long options; I've added it. I don't know if it was on purpose, but it's more useful with it since that is the whole point of being able to search through the options and their descriptions.