### PR TITLE
Add oc / oc.exe as aliases for kubectl tab-completion

### DIFF
--- a/kubectl.lua
+++ b/kubectl.lua
@@ -79,3 +79,5 @@ local kubectl_parser = parser(
 )
 
 clink.arg.register_parser("kubectl", kubectl_parser)
+clink.arg.register_parser("oc", kubectl_parser)
+clink.arg.register_parser("oc.exe", kubectl_parser)


### PR DESCRIPTION
## Summary

- Registers `oc` and `oc.exe` with the existing `kubectl_parser`
- OpenShift CLI (`oc`) is a kubectl superset, so the parser covers all shared subcommands and flags with no duplication

## Changes

Two additional `register_parser` calls at the bottom of `kubectl.lua`:

```lua
clink.arg.register_parser("oc", kubectl_parser)
clink.arg.register_parser("oc.exe", kubectl_parser)
```

## Testing

Verified locally with a Lua 5.1 smoke test that mocked the `clink` global and confirmed all three commands (`kubectl`, `oc`, `oc.exe`) are registered and share the same parser instance.