### PR TITLE
Have argmatchers to only register when command is installed

### DIFF
--- a/angular-cli.lua
+++ b/angular-cli.lua
@@ -191,4 +191,11 @@ local ng_parser = parser({
     "github-pages:deploy"..github_pages_parser
 })
 
-clink.arg.register_parser("ng", ng_parser)
+local function has_cmd(cmd)
+    local ok = os.execute("where " .. cmd .. " >nul 2>nul")
+    return ok == true or ok == 0
+end
+
+if has_cmd("ng") then
+    clink.arg.register_parser("ng", ng_parser)
+end

--- a/chocolatey.lua
+++ b/chocolatey.lua
@@ -1,8 +1,8 @@
 local w = require('tables').wrap
 local path = require('path')
+local install = clink.get_env('chocolateyinstall')
 
 local packages = function (token)
-    local install = clink.get_env('chocolateyinstall')
     if install then
         return w(clink.find_dirs(clink.get_env('chocolateyinstall')..'/lib/*'))
         :filter(function(dir)
@@ -113,9 +113,11 @@ local chocolatey_parser = parser({
     "uninstall"..cuninst_parser
     }, "/?")
 
-clink.arg.register_parser("choco", chocolatey_parser)
-clink.arg.register_parser("chocolatey", chocolatey_parser)
-clink.arg.register_parser("cinst", cinst_parser)
-clink.arg.register_parser("clist", clist_parser)
-clink.arg.register_parser("cuninst", cuninst_parser)
-clink.arg.register_parser("cup", cup_parser)
+if install then
+    clink.arg.register_parser("choco", chocolatey_parser)
+    clink.arg.register_parser("chocolatey", chocolatey_parser)
+    clink.arg.register_parser("cinst", cinst_parser)
+    clink.arg.register_parser("clist", clist_parser)
+    clink.arg.register_parser("cuninst", cuninst_parser)
+    clink.arg.register_parser("cup", cup_parser)
+end

--- a/coho.lua
+++ b/coho.lua
@@ -92,4 +92,11 @@ local coho_parser = parser(
     "-h"
     )
 
-clink.arg.register_parser("coho", coho_parser)
+local function has_cmd(cmd)
+    local ok = os.execute("where " .. cmd .. " >nul 2>nul")
+    return ok == true or ok == 0
+end
+
+if has_cmd("coho") then
+    clink.arg.register_parser("coho", coho_parser)
+end

--- a/cordova.lua
+++ b/cordova.lua
@@ -95,5 +95,11 @@ local cordova_parser = parser(
     "-v", "--version",
     "-d", "--verbose")
 
-clink.arg.register_parser("cordova", cordova_parser)
-clink.arg.register_parser("cordova-dev", cordova_parser)
+local function has_cmd(cmd)
+    local ok = os.execute("where " .. cmd .. " >nul 2>nul")
+    return ok == true or ok == 0
+end
+
+for _, cmd in ipairs({"cordova", "cordova-dev"}) do
+    if has_cmd(cmd) then clink.arg.register_parser(cmd, cordova_parser) end
+end

--- a/dotnet.lua
+++ b/dotnet.lua
@@ -431,4 +431,11 @@ dotnet_parser:add_flags(
     "--help", "--info", "--list-sdks", "--list-runtimes"
 )
 
-clink.arg.register_parser("dotnet", dotnet_parser)
+local function has_cmd(cmd)
+    local ok = os.execute("where " .. cmd .. " >nul 2>nul")
+    return ok == true or ok == 0
+end
+
+if has_cmd("dotnet") then
+    clink.arg.register_parser("dotnet", dotnet_parser)
+end

--- a/kubectl.lua
+++ b/kubectl.lua
@@ -78,5 +78,11 @@ local kubectl_parser = parser(
 	}
 )
 
-clink.arg.register_parser("kubectl", kubectl_parser)
-clink.arg.register_parser("oc", kubectl_parser)
+local function has_cmd(cmd)
+    local ok = os.execute("where " .. cmd .. " >nul 2>nul")
+    return ok == true or ok == 0
+end
+
+for _, cmd in ipairs({"kubectl", "oc"}) do
+    if has_cmd(cmd) then clink.arg.register_parser(cmd, kubectl_parser) end
+end

--- a/npm.lua
+++ b/npm.lua
@@ -212,7 +212,14 @@ local npm_parser = parser({
     "-h", "--version"
 )
 
-clink.arg.register_parser("npm", npm_parser)
+local function has_cmd(cmd)
+    local ok = os.execute("where " .. cmd .. " >nul 2>nul")
+    return ok == true or ok == 0
+end
+
+if has_cmd("npm") then
+    clink.arg.register_parser("npm", npm_parser)
+end
 
 local function escape_percents(s)
     return s:gsub('%%', '%%%%')

--- a/nvm.lua
+++ b/nvm.lua
@@ -43,4 +43,11 @@ local nvm_parser = parser({
     "version", "v"
 }, "-h", "--help", "-v", "--version")
 
-clink.arg.register_parser("nvm", nvm_parser)
+local function has_cmd(cmd)
+    local ok = os.execute("where " .. cmd .. " >nul 2>nul")
+    return ok == true or ok == 0
+end
+
+if has_cmd("nvm") then
+    clink.arg.register_parser("nvm", nvm_parser)
+end

--- a/scoop.lua
+++ b/scoop.lua
@@ -490,4 +490,12 @@ scoop_parser:set_arguments(
         "which"
     }
 )
-clink.arg.register_parser("scoop", scoop_parser)
+
+local function has_cmd(cmd)
+    local ok = os.execute("where " .. cmd .. " >nul 2>nul")
+    return ok == true or ok == 0
+end
+
+if has_cmd("scoop") then
+    clink.arg.register_parser("scoop", scoop_parser)
+end

--- a/vagrant.lua
+++ b/vagrant.lua
@@ -137,5 +137,12 @@ local help_parser = parser({
     "help" .. parser(vagrant_parser:flatten_argument(1))
 })
 
-clink.arg.register_parser("vagrant", vagrant_parser)
-clink.arg.register_parser("vagrant", help_parser)
+local function has_cmd(cmd)
+    local ok = os.execute("where " .. cmd .. " >nul 2>nul")
+    return ok == true or ok == 0
+end
+
+if has_cmd("vagrant") then
+    clink.arg.register_parser("vagrant", vagrant_parser)
+    clink.arg.register_parser("vagrant", help_parser)
+end

--- a/yarn.lua
+++ b/yarn.lua
@@ -222,4 +222,11 @@ local yarn_parser = parser({
     "--version"
 )
 
-clink.arg.register_parser("yarn", yarn_parser)
+local function has_cmd(cmd)
+    local ok = os.execute("where " .. cmd .. " >nul 2>nul")
+    return ok == true or ok == 0
+end
+
+if has_cmd("yarn") then
+    clink.arg.register_parser("yarn", yarn_parser)
+end


### PR DESCRIPTION
This PR updates multiple completion scripts to only 
```lua
clink.arg.register_parser("<executable_name>", <executable_name>_parser)
```
when an executable is present in `%PATH%`. This way,
a program that has not been installed will remain highlighted with `color.unrecognized`.